### PR TITLE
Add environment variable to not force asynchronous publish mode

### DIFF
--- a/rmw_connextdds_common/include/rmw_connextdds/context.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/context.hpp
@@ -82,6 +82,7 @@ struct rmw_context_impl_t
   std::string qos_library;
   std::string qos_ctx_name;
   std::string qos_ctx_namespace;
+  bool override_publish_mode;
 
   /* Participant reference count*/
   size_t node_count{0};

--- a/rmw_connextdds_common/include/rmw_connextdds/static_config.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/static_config.hpp
@@ -45,6 +45,10 @@
 #define RMW_CONNEXT_ENV_QOS_LIBRARY     "RMW_CONNEXT_QOS_LIBRARY"
 #endif /* RMW_CONNEXT_ENV_QOS_LIBRARY */
 
+#ifndef RMW_CONNEXT_ENV_DO_NOT_OVERRIDE_PUBLISH_MODE
+#define RMW_CONNEXT_ENV_DO_NOT_OVERRIDE_PUBLISH_MODE     "RMW_CONNEXT_DO_NOT_OVERRIDE_PUBLISH_MODE"
+#endif /* RMW_CONNEXT_ENV_DO_NOT_OVERRIDE_PUBLISH_MODE */
+
 /******************************************************************************
  * DDS Implementation
  * Select the DDS implementation used to build the RMW library.

--- a/rmw_connextdds_common/src/common/rmw_context.cpp
+++ b/rmw_connextdds_common/src/common/rmw_context.cpp
@@ -184,6 +184,25 @@ rmw_context_impl_t::initialize_node(
 
   this->qos_library = qos_library;
 
+  /* Lookup name of custom QoS library */
+  const char * do_not_override_publish_mode_env = nullptr;
+  lookup_rc = rcutils_get_env(
+    RMW_CONNEXT_ENV_DO_NOT_OVERRIDE_PUBLISH_MODE, &do_not_override_publish_mode_env);
+
+  if (nullptr != lookup_rc || nullptr == qos_library) {
+    RMW_CONNEXT_LOG_ERROR_A_SET(
+      "failed to lookup from environment: "
+      "var=%s, "
+      "rc=%s ",
+      RMW_CONNEXT_ENV_DO_NOT_OVERRIDE_PUBLISH_MODE,
+      lookup_rc)
+    return RMW_RET_ERROR;
+  }
+
+  // All publishers will use asynchronous publish mode if
+  // RMW_CONNEXT_ENV_DO_NOT_OVERRIDE_PUBLISH_MODE is empty.
+  this->override_publish_mode = '\0' == do_not_override_publish_mode_env[0];
+
   if (RMW_RET_OK != rmw_connextdds_initialize_participant_factory(this)) {
     RMW_CONNEXT_LOG_ERROR(
       "failed to initialize DDS DomainParticipantFactory")

--- a/rmw_connextdds_common/src/ndds/dds_api_ndds.cpp
+++ b/rmw_connextdds_common/src/ndds/dds_api_ndds.cpp
@@ -350,7 +350,6 @@ rmw_connextdds_get_datawriter_qos(
 #endif /* RMW_CONNEXT_HAVE_OPTIONS_PUBSUB */
 )
 {
-  UNUSED_ARG(ctx);
   UNUSED_ARG(topic);
 
   if (RMW_RET_OK !=
@@ -379,7 +378,9 @@ rmw_connextdds_get_datawriter_qos(
     return RMW_RET_ERROR;
   }
 
-  qos->publish_mode.kind = DDS_ASYNCHRONOUS_PUBLISH_MODE_QOS;
+  if (ctx->override_publish_mode) {
+    qos->publish_mode.kind = DDS_ASYNCHRONOUS_PUBLISH_MODE_QOS;
+  }
 
   return rmw_connextdds_get_qos_policies(
     true /* writer_qos */,


### PR DESCRIPTION
Currently we're forcing asynchronous publish mode in all publishers for all rmw implementations that have the option available.
This might not be suitable for all use cases.

This PR adds an environment variable to avoid that behavior, so users can specify the publish mode in a qos profile file à la DDS way (if desired using topic filters, etc).

`rmw_connext_cpp` used a similar env variable (see [here](https://github.com/ros2/rmw_connext/blob/fd3e6a71fee0f7eb26f84505d16169ce489d6235/rmw_connext_shared_cpp/src/init.cpp#L117)).
`rmw_fastrtps_cpp` provides a similar env variable (see [here](https://github.com/ros2/rmw_fastrtps/blob/fe2fcb9c627a21433549314c209892fb5646b9b1/README.md#change-publication-mode)).