### PR TITLE
get valid subscription handle even if cft failed

### DIFF
--- a/rmw_connextdds_common/include/rmw_connextdds/rmw_impl.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/rmw_impl.hpp
@@ -487,7 +487,7 @@ public:
 
   bool is_cft_enabled()
   {
-    return !this->cft_expression.empty();
+    return this->dds_topic_cft != nullptr;
   }
 
   const bool internal;

--- a/rmw_connextdds_common/include/rmw_connextdds/rmw_impl.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/rmw_impl.hpp
@@ -487,7 +487,7 @@ public:
 
   bool is_cft_enabled()
   {
-    return this->dds_topic_cft != nullptr;
+    return !this->cft_expression.empty();
   }
 
   const bool internal;

--- a/rmw_connextdds_common/src/common/rmw_impl.cpp
+++ b/rmw_connextdds_common/src/common/rmw_impl.cpp
@@ -1296,6 +1296,9 @@ RMW_Connext_Subscriber::create(
 
   if (RMW_RET_OK == cft_rc) {
     sub_topic = cft_topic;
+  } else {
+    // RMW_Connext_Subscriber needs this value to check if CFT is enabled or not.
+    sub_cft_expr = "";
   }
 
   // The following initialization generates warnings when built

--- a/rmw_connextdds_common/src/common/rmw_impl.cpp
+++ b/rmw_connextdds_common/src/common/rmw_impl.cpp
@@ -1294,11 +1294,7 @@ RMW_Connext_Subscriber::create(
     sub_cft_params,
     &cft_topic);
 
-  if (RMW_RET_OK != cft_rc) {
-    if (RMW_RET_UNSUPPORTED != cft_rc) {
-      return nullptr;
-    }
-  } else {
+  if (RMW_RET_OK == cft_rc) {
     sub_topic = cft_topic;
   }
 


### PR DESCRIPTION
rcl need to continue to try rcl cft fallback if rmw implementation failed to call rmw cft.