### PR TITLE
Backport rmw callbacks implementation to Humble [ros2-73]

### DIFF
--- a/rmw_connextdds_common/include/rmw_connextdds/dds_api.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/dds_api.hpp
@@ -139,6 +139,11 @@ rmw_connextdds_take_samples(
   RMW_Connext_Subscriber * const sub);
 
 rmw_ret_t
+rmw_connextdds_count_unread_samples(
+  RMW_Connext_Subscriber * const sub,
+  size_t & unread_count);
+
+rmw_ret_t
 rmw_connextdds_return_samples(
   RMW_Connext_Subscriber * const sub);
 

--- a/rmw_connextdds_common/include/rmw_connextdds/rmw_api_impl.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/rmw_api_impl.hpp
@@ -92,8 +92,8 @@ RMW_CONNEXTDDS_PUBLIC
 rmw_ret_t
 rmw_api_connextdds_event_set_callback(
   rmw_event_t * event,
-  rmw_event_callback_t callback,
-  const void * user_data);
+  const rmw_event_callback_t callback,
+  const void * const user_data);
 
 /*****************************************************************************
  * Info API
@@ -437,15 +437,15 @@ RMW_CONNEXTDDS_PUBLIC
 rmw_ret_t
 rmw_api_connextdds_service_set_on_new_request_callback(
   rmw_service_t * rmw_service,
-  rmw_event_callback_t callback,
-  const void * user_data);
+  const rmw_event_callback_t callback,
+  const void * const user_data);
 
 RMW_CONNEXTDDS_PUBLIC
 rmw_ret_t
 rmw_api_connextdds_client_set_on_new_response_callback(
   rmw_client_t * rmw_client,
-  rmw_event_callback_t callback,
-  const void * user_data);
+  const rmw_event_callback_t callback,
+  const void * const user_data);
 
 /*****************************************************************************
  * Subscription API
@@ -574,9 +574,9 @@ rmw_api_connextdds_return_loaned_message_from_subscription(
 RMW_CONNEXTDDS_PUBLIC
 rmw_ret_t
 rmw_api_connextdds_subscription_set_on_new_message_callback(
-  rmw_subscription_t * rmw_subscription,
-  rmw_event_callback_t callback,
-  const void * user_data);
+  rmw_subscription_t * const rmw_subscription,
+  const rmw_event_callback_t callback,
+  const void * const user_data);
 
 /*****************************************************************************
  * WaitSet API

--- a/rmw_connextdds_common/include/rmw_connextdds/rmw_waitset_std.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/rmw_waitset_std.hpp
@@ -16,6 +16,7 @@
 #define RMW_CONNEXTDDS__RMW_WAITSET_STD_HPP_
 
 #include "rmw_connextdds/context.hpp"
+#include <condition_variable>
 
 /******************************************************************************
  * Alternative implementation of WaitSets and Conditions using C++ std
@@ -118,6 +119,22 @@ public:
 
     if (notify && nullptr != this->waitset_condition) {
       this->waitset_condition->notify_one();
+    }
+  }
+
+  template<typename FunctorT, typename FunctorA>
+  void
+  perform_action_and_update_state(FunctorA && action, FunctorT && update_condition)
+  {
+    std::lock_guard<std::mutex> internal_lock(this->mutex_internal);
+
+    action();
+
+    if (nullptr != this->waitset_mutex) {
+      std::lock_guard<std::mutex> lock(*this->waitset_mutex);
+      update_condition();
+    } else {
+      update_condition();
     }
   }
 
@@ -333,8 +350,55 @@ public:
   virtual bool
   has_status(const rmw_event_type_t event_type) = 0;
 
+  void
+  notify_new_event(rmw_event_type_t event_type)
+  {
+    std::unique_lock<std::mutex> lock_mutex(new_event_mutex_);
+    if (new_event_cb_[event_type]) {
+      new_event_cb_[event_type](user_data_[event_type], 1);
+    } else {
+      unread_events_count_[event_type]++;
+    }
+  }
+
+  void
+  set_new_event_callback(
+    rmw_event_type_t event_type,
+    rmw_event_callback_t callback,
+    const void * user_data)
+  {
+    std::unique_lock<std::mutex> lock_mutex(new_event_mutex_);
+
+    if (callback) {
+      // Push events arrived before setting the executor's callback
+      if (unread_events_count_[event_type] > 0) {
+        callback(user_data, unread_events_count_[event_type]);
+        unread_events_count_[event_type] = 0;
+      }
+      user_data_[event_type] = user_data;
+      new_event_cb_[event_type] = callback;
+    } else {
+      user_data_[event_type] = nullptr;
+      new_event_cb_[event_type] = nullptr;
+    }
+  }
+
+  void
+  on_inconsistent_topic(const struct DDS_InconsistentTopicStatus * status);
+
+  void
+  update_status_inconsistent_topic(const struct DDS_InconsistentTopicStatus * status);
+
 protected:
   DDS_StatusCondition * scond;
+  std::mutex new_event_mutex_;
+  rmw_event_callback_t new_event_cb_[RMW_EVENT_INVALID] = {};
+  const void * user_data_[RMW_EVENT_INVALID] = {};
+  uint64_t unread_events_count_[RMW_EVENT_INVALID] = {0};
+
+  bool triggered_inconsistent_topic{false};
+
+  struct DDS_InconsistentTopicStatus status_inconsistent_topic;
 };
 
 void
@@ -712,6 +776,26 @@ public:
     return RMW_RET_OK;
   }
 
+  void set_on_new_data_callback(
+    const rmw_event_callback_t callback,
+    const void * const user_data)
+  {
+    std::unique_lock<std::mutex> lock(new_data_event_mutex_);
+    if (callback) {
+      if (unread_data_events_count_ > 0) {
+        callback(user_data, unread_data_events_count_);
+        unread_data_events_count_ = 0;
+      }
+      new_data_event_cb_ = callback;
+      data_event_user_data_ = user_data;
+    } else {
+      new_data_event_cb_ = nullptr;
+      data_event_user_data_ = nullptr;
+    }
+  }
+
+  void notify_new_data();
+
 protected:
   void update_status_deadline(
     const DDS_RequestedDeadlineMissedStatus * const status);
@@ -744,6 +828,11 @@ protected:
   DDS_SampleLostStatus status_sample_lost_last;
 
   RMW_Connext_Subscriber * sub;
+
+  std::mutex new_data_event_mutex_;
+  rmw_event_callback_t new_data_event_cb_{nullptr};
+  const void * data_event_user_data_{nullptr};
+  uint64_t unread_data_events_count_ = 0;
 
   friend class RMW_Connext_WaitSet;
 };

--- a/rmw_connextdds_common/include/rmw_connextdds/rmw_waitset_std.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/rmw_waitset_std.hpp
@@ -15,8 +15,8 @@
 #ifndef RMW_CONNEXTDDS__RMW_WAITSET_STD_HPP_
 #define RMW_CONNEXTDDS__RMW_WAITSET_STD_HPP_
 
-#include "rmw_connextdds/context.hpp"
 #include <condition_variable>
+#include "rmw_connextdds/context.hpp"
 
 /******************************************************************************
  * Alternative implementation of WaitSets and Conditions using C++ std

--- a/rmw_connextdds_common/src/common/rmw_listener.cpp
+++ b/rmw_connextdds_common/src/common/rmw_listener.cpp
@@ -19,15 +19,25 @@
  ******************************************************************************/
 rmw_ret_t
 rmw_api_connextdds_event_set_callback(
-  rmw_event_t * event,
-  rmw_event_callback_t callback,
-  const void * user_data)
+  rmw_event_t * const event,
+  const rmw_event_callback_t callback,
+  const void * const user_data)
 {
-  UNUSED_ARG(event);
-  UNUSED_ARG(callback);
-  UNUSED_ARG(user_data);
-  RMW_CONNEXT_LOG_ERROR_SET("rmw_event_set_callback not implemented")
-  return RMW_RET_UNSUPPORTED;
+  RMW_CHECK_ARGUMENT_FOR_NULL(event, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    event,
+    event->implementation_identifier,
+    RMW_CONNEXTDDS_ID,
+    return RMW_RET_INVALID_ARGUMENT);
+
+  RMW_Connext_StatusCondition * condition = nullptr;
+  if (RMW_Connext_Event::reader_event(event)) {
+    condition = RMW_Connext_Event::subscriber(event)->condition();
+  } else {
+    condition = RMW_Connext_Event::publisher(event)->condition();
+  }
+  condition->set_new_event_callback(event->event_type, callback, user_data);
+  return RMW_RET_OK;
 }
 
 /******************************************************************************
@@ -35,28 +45,40 @@ rmw_api_connextdds_event_set_callback(
  ******************************************************************************/
 rmw_ret_t
 rmw_api_connextdds_service_set_on_new_request_callback(
-  rmw_service_t * rmw_service,
-  rmw_event_callback_t callback,
-  const void * user_data)
+  rmw_service_t * const service,
+  const rmw_event_callback_t callback,
+  const void * const user_data)
 {
-  UNUSED_ARG(rmw_service);
-  UNUSED_ARG(callback);
-  UNUSED_ARG(user_data);
-  RMW_CONNEXT_LOG_ERROR_SET("rmw_service_set_on_new_request_callback not implemented")
-  return RMW_RET_UNSUPPORTED;
+  RMW_CHECK_ARGUMENT_FOR_NULL(service, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    service,
+    service->implementation_identifier,
+    RMW_CONNEXTDDS_ID,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+
+  RMW_Connext_Service * const svc_impl =
+    reinterpret_cast<RMW_Connext_Service *>(service->data);
+  svc_impl->subscriber()->condition()->set_on_new_data_callback(callback, user_data);
+  return RMW_RET_OK;
 }
 
 rmw_ret_t
 rmw_api_connextdds_client_set_on_new_response_callback(
-  rmw_client_t * rmw_client,
-  rmw_event_callback_t callback,
-  const void * user_data)
+  rmw_client_t * const client,
+  const rmw_event_callback_t callback,
+  const void * const user_data)
 {
-  UNUSED_ARG(rmw_client);
-  UNUSED_ARG(callback);
-  UNUSED_ARG(user_data);
-  RMW_CONNEXT_LOG_ERROR_SET("rmw_client_set_on_new_response_callback not implemented")
-  return RMW_RET_UNSUPPORTED;
+  RMW_CHECK_ARGUMENT_FOR_NULL(client, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    client,
+    client->implementation_identifier,
+    RMW_CONNEXTDDS_ID,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+
+  RMW_Connext_Client * const client_impl =
+    reinterpret_cast<RMW_Connext_Client *>(client->data);
+  client_impl->subscriber()->condition()->set_on_new_data_callback(callback, user_data);
+  return RMW_RET_OK;
 }
 
 /******************************************************************************
@@ -64,13 +86,19 @@ rmw_api_connextdds_client_set_on_new_response_callback(
  ******************************************************************************/
 rmw_ret_t
 rmw_api_connextdds_subscription_set_on_new_message_callback(
-  rmw_subscription_t * rmw_subscription,
-  rmw_event_callback_t callback,
-  const void * user_data)
+  rmw_subscription_t * const subscription,
+  const rmw_event_callback_t callback,
+  const void * const user_data)
 {
-  UNUSED_ARG(rmw_subscription);
-  UNUSED_ARG(callback);
-  UNUSED_ARG(user_data);
-  RMW_CONNEXT_LOG_ERROR_SET("rmw_subscription_set_on_new_message_callback not implemented")
-  return RMW_RET_UNSUPPORTED;
+  RMW_CHECK_ARGUMENT_FOR_NULL(subscription, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    subscription,
+    subscription->implementation_identifier,
+    RMW_CONNEXTDDS_ID,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+
+  RMW_Connext_Subscriber * const sub_impl =
+    reinterpret_cast<RMW_Connext_Subscriber *>(subscription->data);
+  sub_impl->condition()->set_on_new_data_callback(callback, user_data);
+  return RMW_RET_OK;
 }

--- a/rmw_connextdds_common/src/ndds/dds_api_ndds.cpp
+++ b/rmw_connextdds_common/src/ndds/dds_api_ndds.cpp
@@ -824,6 +824,62 @@ rmw_connextdds_return_samples(
   return RMW_RET_OK;
 }
 
+rmw_ret_t
+rmw_connextdds_count_unread_samples(
+  RMW_Connext_Subscriber * const sub,
+  size_t & unread_count)
+{
+  DDS_Boolean is_loan = DDS_BOOLEAN_TRUE;
+  DDS_Long data_len = 0;
+  void ** data_buffer = nullptr;
+  DDS_SampleInfoSeq info_seq = DDS_SEQUENCE_INITIALIZER;
+
+  unread_count = 0;
+  DDS_ReturnCode_t rc = DDS_RETCODE_ERROR;
+  do {
+    rc = DDS_DataReader_read_or_take_instance_untypedI(
+      sub->reader(),
+      &is_loan,
+      &data_buffer,
+      &data_len,
+      &info_seq,
+      0 /* data_seq_len */,
+      0 /* data_seq_max_len */,
+      DDS_BOOLEAN_TRUE /* data_seq_has_ownership */,
+      NULL /* data_seq_contiguous_buffer_for_copy */,
+      1 /* data_size -- ignored because loaning*/,
+      DDS_LENGTH_UNLIMITED /* max_samples */,
+      &DDS_HANDLE_NIL /* a_handle */,
+  #if !RMW_CONNEXT_DDS_API_PRO_LEGACY
+      NULL /* topic_query_guid */,
+  #endif /* RMW_CONNEXT_DDS_API_PRO_LEGACY */
+      DDS_NOT_READ_SAMPLE_STATE,
+      DDS_ANY_VIEW_STATE,
+      DDS_ANY_INSTANCE_STATE,
+      DDS_BOOLEAN_FALSE /* take */);
+    if (DDS_RETCODE_NO_DATA == rc) {
+      continue;
+    }
+    if (DDS_RETCODE_OK != rc && DDS_RETCODE_NO_DATA != rc) {
+      RMW_CONNEXT_LOG_ERROR_SET("failed to read data from DDS reader")
+      return RMW_RET_ERROR;
+    }
+    if (DDS_RETCODE_OK == rc) {
+      unread_count += data_len;
+      rc = DDS_DataReader_return_loan_untypedI(
+        sub->reader(),
+        data_buffer,
+        data_len,
+        &info_seq);
+      if (DDS_RETCODE_OK != rc) {
+        RMW_CONNEXT_LOG_ERROR_SET("failed to return loan to DDS reader")
+        return RMW_RET_ERROR;
+      }
+    }
+  } while (rc == DDS_RETCODE_OK);
+
+  return RMW_RET_OK;
+}
 
 rmw_ret_t
 rmw_connextdds_filter_sample(

--- a/rmw_connextdds_common/src/ndds/dds_api_ndds.cpp
+++ b/rmw_connextdds_common/src/ndds/dds_api_ndds.cpp
@@ -804,19 +804,29 @@ rmw_connextdds_return_samples(
 {
   void ** data_buffer = reinterpret_cast<void **>(
     RMW_Connext_MessagePtrSeq_get_contiguous_buffer(sub->data_seq()));
-  const DDS_Long data_len =
-    RMW_Connext_MessagePtrSeq_get_length(sub->data_seq());
 
   if (!RMW_Connext_MessagePtrSeq_unloan(sub->data_seq())) {
     RMW_CONNEXT_LOG_ERROR_SET("failed to unloan sample sequence")
     return RMW_RET_ERROR;
   }
+  // DDS_DataReader_return_loan_untypedI is an internal API, and
+  // its signature changed slightly in Connext 7.x.
+#if RTI_DDS_VERSION_MAJOR < 7
+  const DDS_Long data_len =
+    RMW_Connext_MessagePtrSeq_get_length(sub->data_seq());
   if (DDS_RETCODE_OK !=
     DDS_DataReader_return_loan_untypedI(
       sub->reader(),
       data_buffer,
       data_len,
       sub->info_seq()))
+#else
+  if (DDS_RETCODE_OK !=
+    DDS_DataReader_return_loan_untypedI(
+      sub->reader(),
+      data_buffer,
+      sub->info_seq()))
+#endif  // RTI_DDS_VERSION_MAJOR < 7
   {
     RMW_CONNEXT_LOG_ERROR_SET("failed to return loan to DDS reader")
     return RMW_RET_ERROR;
@@ -866,11 +876,20 @@ rmw_connextdds_count_unread_samples(
     }
     if (DDS_RETCODE_OK == rc) {
       unread_count += data_len;
+      // DDS_DataReader_return_loan_untypedI is an internal API, and
+      // its signature changed slightly in Connext 7.x.
+#if RTI_DDS_VERSION_MAJOR < 7
       rc = DDS_DataReader_return_loan_untypedI(
         sub->reader(),
         data_buffer,
         data_len,
         &info_seq);
+#else
+      rc = DDS_DataReader_return_loan_untypedI(
+        sub->reader(),
+        data_buffer,
+        &info_seq);
+#endif  // RTI_DDS_VERSION_MAJOR < 7
       if (DDS_RETCODE_OK != rc) {
         RMW_CONNEXT_LOG_ERROR_SET("failed to return loan to DDS reader")
         return RMW_RET_ERROR;


### PR DESCRIPTION
This fixes #155. I've also sneakily backported the fix to allow Humble to build with Connext 7.3.0.

`ci_linux`: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux)](https://ci.ros2.org/job/ci_linux/)
`ci_linux_rhel`: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel)](https://ci.ros2.org/job/ci_linux-rhel/)
`ci_windows`: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows)](https://ci.ros2.org/job/ci_windows/)