### PR TITLE
add rmw_get_default_xxx to return the structure with default values.

### DIFF
--- a/rmw_connextdds_common/src/common/rmw_context.cpp
+++ b/rmw_connextdds_common/src/common/rmw_context.cpp
@@ -1106,7 +1106,7 @@ rmw_api_connextdds_init(
   auto scope_exit_context_reset = rcpputils::make_scope_exit(
     [context]()
     {
-      *context = rmw_get_zero_initialized_context();
+      *context = rmw_get_default_context();
     });
 
   context->instance_id = options->instance_id;


### PR DESCRIPTION
aligns with https://github.com/ros2/rmw/pull/379