### PR TITLE
Use target_link_libraries instead of ament_target_dependencies

### DIFF
--- a/rmw_connextdds_common/CMakeLists.txt
+++ b/rmw_connextdds_common/CMakeLists.txt
@@ -58,8 +58,7 @@ function(rtirmw_add_library)
 
     target_link_libraries(${_rti_build_NAME}
         ${_rti_build_LIBRARIES}
-        fastcdr
-	${_rti_build_DEPS})
+        ${_rti_build_DEPS})
 
     set(_extra_defines)
     if("${CMAKE_BUILD_TYPE}" MATCHES "[dD]ebug")
@@ -111,7 +110,7 @@ set(RMW_CONNEXT_TARGET_DEPS
     rmw::rmw
     rmw_dds_common::rmw_dds_common_library
     tracetools::tracetools
-    fastcdr::fastcdr
+    fastcdr
     rosidl_runtime_c::rosidl_runtime_c
     rosidl_runtime_cpp::rosidl_runtime_cpp
     rosidl_typesupport_fastrtps_c::rosidl_typesupport_fastrtps_c

--- a/rmw_connextdds_common/CMakeLists.txt
+++ b/rmw_connextdds_common/CMakeLists.txt
@@ -106,7 +106,7 @@ endfunction()
 # Load external dependencies
 ################################################################################
 set(RMW_CONNEXT_TARGET_DEPS
-    rcutils::rclutils
+    rcutils::rcutils
     rcpputils::rcpputils
     rmw::rmw
     rmw_dds_common::rmw_dds_common_library

--- a/rmw_connextdds_common/CMakeLists.txt
+++ b/rmw_connextdds_common/CMakeLists.txt
@@ -58,10 +58,8 @@ function(rtirmw_add_library)
 
     target_link_libraries(${_rti_build_NAME}
         ${_rti_build_LIBRARIES}
-        fastcdr)
-
-    ament_target_dependencies(${_rti_build_NAME}
-        ${_rti_build_DEPS})
+        fastcdr
+	${_rti_build_DEPS})
 
     set(_extra_defines)
     if("${CMAKE_BUILD_TYPE}" MATCHES "[dD]ebug")
@@ -107,6 +105,19 @@ endfunction()
 ################################################################################
 # Load external dependencies
 ################################################################################
+set(RMW_CONNEXT_TARGET_DEPS
+    rcutils::rclutils
+    rcpputils::rcpputils
+    rmw::rmw
+    rmw_dds_common::rmw_dds_common_library
+    tracetools::tracetools
+    fastcdr::fastcdr
+    rosidl_runtime_c::rosidl_runtime_c
+    rosidl_runtime_cpp::rosidl_runtime_cpp
+    rosidl_typesupport_fastrtps_c::rosidl_typesupport_fastrtps_c
+    rosidl_typesupport_fastrtps_cpp::rosidl_typesupport_fastrtps_cpp
+    rosidl_typesupport_introspection_c::rosidl_typesupport_introspection_c
+    rosidl_typesupport_introspection_cpp::rosidl_typesupport_introspection_cpp)
 set(RMW_CONNEXT_DEPS
     rcutils
     rcpputils
@@ -213,7 +224,7 @@ else()
                   include/rmw_connextdds/typecode.hpp
                   include/rmw_connextdds/dds_api_ndds.hpp
                   include/rmw_connextdds/custom_sql_filter.hpp
-        DEPS      ${RMW_CONNEXT_DEPS}
+        DEPS      ${RMW_CONNEXT_TARGET_DEPS}
         LIBRARIES RTIConnextDDS::c_api
         DEFINES   ${extra_defines})
 endif()
@@ -278,7 +289,7 @@ else()
                 src/rtime/rmw_type_support_rtime.cpp
                 src/rtime/dds_api_rtime.cpp
                 include/rmw_connextdds/dds_api_rtime.hpp
-      DEPS      ${RMW_CONNEXT_DEPS}
+      DEPS      ${RMW_CONNEXT_TARGET_DEPS}
       LIBRARIES RTIConnextDDSMicro::c_api
                 RTIConnextDDSMicro::netiosdm
                 RTIConnextDDSMicro::netioshmem


### PR DESCRIPTION
`ament_target_dependencies` hasn't been necessary for a while, and it can lead to libraries depending on more targets than they actually need. This PR uses target_link_libraries instead.

https://github.com/ament/ament_cmake/issues/292