### PR TITLE
Export a modern CMake target

### DIFF
--- a/rmw_connextdds/CMakeLists.txt
+++ b/rmw_connextdds/CMakeLists.txt
@@ -61,11 +61,13 @@ endif()
 
 install(
     TARGETS ${PROJECT_NAME}
+    EXPORT ${PROJECT_NAME}
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin
 )
 
+ament_export_targets(${PROJECT_NAME})
 ament_export_libraries(${PROJECT_NAME})
 ament_export_dependencies(rmw_connextdds_common)
 


### PR DESCRIPTION
Currently `rmw_connextdds` only exports old style CMake variables. This PR makes it export a modern CMake target.

Downstream packages that depend on `rmw_connextdds` directly can now use `target_link_libraries()` with the modern CMake target like so:

```CMake
target_link_libraries(my_downstream_target PUBLIC rmw_connextdds::rmw_connextdds)
```


I think this should fix CI on https://github.com/ros2/system_tests/pull/566