### PR TITLE
#177: Update Connext to 7.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 # ROS 2 Middleware Layer for RTI Connext DDS
 
-This repository contains two novel implementations of the [ROS 2](https://docs.ros.org/en/rolling)
+This repository contains a implementation of the [ROS 2](https://docs.ros.org/en/rolling)
 RMW layer which allow developers to deploy their ROS applications on top of
 [RTI Connext DDS Professional](https://www.rti.com/products/connext-dds-professional)
-and [RTI Connext DDS Micro](https://www.rti.com/products/connext-dds-micro).
 
 The repository provides two RMW packages:
 
 - `rmw_connextdds`
 
-- `rmw_connextddsmicro`
+- `rmw_connextddsmicro` (deprecated)
 
 Package `rmw_connextdds` is meant to be a replacement for [`rmw_connext_cpp`](https://github.com/ros2/rmw_connext).
 This new implementation resolves several performance issues, and it improves out-of-the-box
@@ -20,7 +19,7 @@ active development.
 Please consider reporting any [issue](https://github.com/rticommunity/rmw_connextdds/issues)
 that you may experience, while monitoring the repository for frequent updates.*
 
-For any questions or feedback, feel free to reach out to robotics@rti.com.
+For any questions or feedback, feel free to reach out to rti-ros-team@rti.com.
 
 ## Quick Start
 
@@ -34,11 +33,11 @@ For any questions or feedback, feel free to reach out to robotics@rti.com.
 2. Configure RTI Connext DDS Professional and/or RTI Connext DDS Micro on your
    system (see [Requirements](#rti-connext-dds-requirements)). Make the installation(s)
    available via environment variables, e.g. by using the provided
-   `rtisetenv_<architecture>.bash` script (replace `~/rti_connext_dds-6.0.1` with
+   `rtisetenv_<architecture>.bash` script (replace `~/rti_connext_dds-7.3.0` with
    the path of your Connext installation):
 
    ```sh
-    source ~/rti_connext_dds-6.0.1/resource/scripts/rtisetenv_x64Linux4gcc7.3.0.bash
+    source ~/rti_connext_dds-7.3.0/resource/scripts/rtisetenv_x64Linux4gcc7.3.0.bash
     export CONNEXTDDS_DIR=${NDDSHOME}
     ```
 
@@ -85,7 +84,7 @@ release:
 |ROS 2 Release|Branch|Status|
 |-------------|------|------|
 |Rolling      |`rolling`|Developed|
-|Iron         |`iron`|Supported until November 2024|
+|Iron         |`iron`|Supported until November 2024 (EOL)|
 |Humble       |`humble`|Supported until May 2027|
 |Galactic     |`galactic`|Supported until November 2022 (EOL)|
 |Foxy         |`foxy`|Supported until May 2023 (EOL)|
@@ -111,8 +110,8 @@ valid installation is detected, the packages will be skipped and not be built.
 
 |RMW|RTI Product|Environment Variable(s)|Required|Default|
 |---|-----------|-----------------------|--------|-------|
-|`rmw_connextdds`|RTI Connext DDS Professional 5.3.1, or 6.x|`CONNEXTDDS_DIR`, or `NDDSHOME`|Yes|None|
-|`rmw_connextddsmicro`|RTI Connext DDS Micro 3.x |`RTIMEHOME`|No (if RTI Connext DDS Professional 6.x is available)|Guessed from contents of RTI Connext DDS Professional installation (6.x only, 5.3.1 users must specify `RTIMEHOME`).|
+|`rmw_connextdds`|RTI Connext DDS Professional 7.3.0|`CONNEXTDDS_DIR`, or `NDDSHOME`|Yes|None|
+|`rmw_connextddsmicro`|RTI Connext DDS Micro 3.x |`RTIMEHOME`|No (if RTI Connext DDS Professional 7.3.0 is available)|Guessed from contents of RTI Connext DDS Professional installation|
 
 ### Multiple versions of RTI Connext DDS Professional
 
@@ -129,7 +128,7 @@ have installed RTI Connext DDS Professional 5.3.1 via the `apt` package
 If `rmw_connext_cpp` is installed via debian package
 `ros-<version>-rmw-connext-cpp`, variable `${NDDSHOME}` will always be
 hard-coded to the install location of the `apt` package
-(`/opt/rti.com/rti_connext_dds-5.3.1`).
+(`/opt/rti.com/rti_connext_dds-<version>`).
 
 In this case, you can use `${CONNEXTDDS_DIR}` to point to a Connext 6.x
 installation, making sure to source script
@@ -211,9 +210,9 @@ its defaults.
 ### RMW_CONNEXT_DISABLE_RELIABILITY_OPTIMIZATIONS
 
 By default, `rmw_connextdds` will modify the QoS of each reliable DataWriter
-and DataReader to improve the responsiveness of the RTPS [reliability protocol](https://community.rti.com/static/documentation/connext-dds/6.0.1/doc/manuals/connext_dds/html_files/RTI_ConnextDDS_CoreLibraries_UsersManual/Content/UsersManual/Using_QosPolicies_to_Tune_the_Reliable_P.htm?tocpath=Part%203%3A%20Advanced%20Concepts%7C11.%20Reliable%20Communications%7C11.3%20Using%20QosPolicies%20to%20Tune%20the%20Reliable%20Protocol%7C_____0#reliable_1394042328_776265).
+and DataReader to improve the responsiveness of the RTPS [reliability protocol](https://community.rti.com/static/documentation/connext-dds/7.3.0/doc/manuals/connext_dds/html_files/RTI_ConnextDDS_CoreLibraries_UsersManual/Content/UsersManual/Using_QosPolicies_to_Tune_the_Reliable_P.htm?tocpath=Part%203%3A%20Advanced%20Concepts%7C11.%20Reliable%20Communications%7C11.3%20Using%20QosPolicies%20to%20Tune%20the%20Reliable%20Protocol%7C_____0#reliable_1394042328_776265).
 
-For example, the ["heartbeat period"](https://community.rti.com/static/documentation/connext-dds/6.0.1/doc/manuals/connext_dds/html_files/RTI_ConnextDDS_CoreLibraries_UsersManual/Content/UsersManual/Controlling_Heartbeats_and_Retries.htm#reliable_1394042328_785637)
+For example, the ["heartbeat period"](https://community.rti.com/static/documentation/connext-dds/7.3.0/doc/manuals/connext_dds/html_files/RTI_ConnextDDS_CoreLibraries_UsersManual/Content/UsersManual/Controlling_Heartbeats_and_Retries.htm#reliable_1394042328_785637)
 is sped up from 3 seconds to 100 milliseconds.
 
 These optimizations may be disabled using variable
@@ -258,7 +257,7 @@ The values will be parsed, trimmed, and stored in QoS field
 value it previously contained.
 
 While both `rmw_connextdds` and `rmw_connextddsmicro` will honor this variable,
-[equivalent, and more advanced, functionality is already available in RTI Connext DDS](https://community.rti.com/static/documentation/connext-dds/6.0.1/doc/manuals/connext_dds/html_files/RTI_ConnextDDS_CoreLibraries_UsersManual/Content/UsersManual/ConfigPeersListUsed_inDiscov.htm),
+[equivalent, and more advanced, functionality is already available in RTI Connext DDS](https://community.rti.com/static/documentation/connext-dds/7.3.0/doc/manuals/connext_dds/html_files/RTI_ConnextDDS_CoreLibraries_UsersManual/Content/UsersManual/ConfigPeersListUsed_inDiscov.htm),
 for example using variable `NDDS_DISCOVERY_PEERS`.
 
 For this reason, only users of `rmw_connextddsmicro` should consider specifying

--- a/rti_connext_dds_cmake_module/package.xml
+++ b/rti_connext_dds_cmake_module/package.xml
@@ -10,7 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
 
-  <depend>rti-connext-dds-7.3.0-ros</depend>
+  <depend>rti-connext-dds-7.3.0</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rti_connext_dds_cmake_module/package.xml
+++ b/rti_connext_dds_cmake_module/package.xml
@@ -10,7 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
 
-  <depend>rti-connext-dds-7.3.0</depend>
+  <depend>rti-connext-dds-7.3.0-ros</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rti_connext_dds_cmake_module/package.xml
+++ b/rti_connext_dds_cmake_module/package.xml
@@ -10,7 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
 
-  <depend>rti-connext-dds-6.0.1</depend>
+  <depend>rti-connext-dds-7.3.0</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
This PR intends to update the rmw_connextmodule to use  RTI Connext DDS 7.3.0 as explained in https://github.com/ros2/rmw_connextdds/issues/177

we will need also the work on: 

ROS CI PR: https://github.com/ros2/ci/pull/811
rosdistro PR: https://github.com/ros/rosdistro/pull/44918