### PR TITLE
Mark the package rmw_connextddsmicro as deprecated

### DIFF
--- a/rmw_connextddsmicro/package.xml
+++ b/rmw_connextddsmicro/package.xml
@@ -21,8 +21,7 @@
     <build_type>ament_cmake</build_type>
     
     <deprecated>
-        The Connext Micro RMW, rmw_connextddsmicro, will be removed in a future ROS 2 distro. Use
-        the Connext Pro RMW, rmw_connextdds, instead.
+      This package will be removed in a future ROS 2 distro. Use rmw_connextdds instead.
     </deprecated>
   </export>
 </package>

--- a/rmw_connextddsmicro/package.xml
+++ b/rmw_connextddsmicro/package.xml
@@ -19,5 +19,10 @@
 
   <export>
     <build_type>ament_cmake</build_type>
+    
+    <deprecated>
+        The Connext Micro RMW, rmw_connextddsmicro, will be removed in a future ROS 2 distro. Use
+        the Connext Pro RMW, rmw_connextdds, instead.
+    </deprecated>
   </export>
 </package>


### PR DESCRIPTION
Part of https://github.com/ros2/rmw_connextdds/issues/180. The deprecation and removal of both the `rmw_connextddsmicro` and the common module, `rmw_connextdds_common`, will be done in the next release cycle.