### PR TITLE
Switch buildtool to ament_cmake package

### DIFF
--- a/rmw_connextdds/package.xml
+++ b/rmw_connextdds/package.xml
@@ -7,7 +7,7 @@
   <maintainer email="asorbini@rti.com">Andrea Sorbini</maintainer>
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
 
   <depend>rmw_connextdds_common</depend>

--- a/rmw_connextdds_common/package.xml
+++ b/rmw_connextdds_common/package.xml
@@ -7,7 +7,7 @@
   <maintainer email="asorbini@rti.com">Andrea Sorbini</maintainer>
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
 
   <depend>rti_connext_dds_cmake_module</depend>

--- a/rmw_connextddsmicro/package.xml
+++ b/rmw_connextddsmicro/package.xml
@@ -7,7 +7,7 @@
   <maintainer email="asorbini@rti.com">Andrea Sorbini</maintainer>
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
 
   <depend>rmw_connextdds_common</depend>


### PR DESCRIPTION
These packages don't actually `find_package(ament_cmake_ros)` at all, so the dependency can be tightened significantly.

Part of ros2/ament_cmake_ros#20

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=23038)](http://ci.ros2.org/job/ci_linux/23038/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=17260)](http://ci.ros2.org/job/ci_linux-aarch64/17260/)
* Linux-rhel [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=2518)](http://ci.ros2.org/job/ci_linux-rhel/2518/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=23911)](http://ci.ros2.org/job/ci_windows/23911/)