### PR TITLE
address cpplit and gcc warnings.

### DIFF
--- a/rmw_connextdds_common/src/common/rmw_type_support.cpp
+++ b/rmw_connextdds_common/src/common/rmw_type_support.cpp
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <exception>
 #include <string.h>
+
+#include <exception>
 #include <string>
 
 #include "rcpputils/scope_exit.hpp"

--- a/rmw_connextdds_common/src/ndds/rmw_type_support_ndds.cpp
+++ b/rmw_connextdds_common/src/ndds/rmw_type_support_ndds.cpp
@@ -1045,6 +1045,11 @@ RMW_Connext_TypePlugin_serialized_sample_to_key_hash(
   RTIBool deserializeEncapsulation,
   void *endpointPluginQos)
 {
+  UNUSED_ARG(endpointData);
+  UNUSED_ARG(stream);
+  UNUSED_ARG(keyHash);
+  UNUSED_ARG(deserializeEncapsulation);
+  UNUSED_ARG(endpointPluginQos);
   return RTI_FALSE;
 }
 


### PR DESCRIPTION
fix cpplit and gcc warnings introduced by https://github.com/ros2/rmw_connextdds/pull/178

see CI failures and warnings for https://ci.ros2.org/job/ci_linux/23077/