### PR TITLE
Removed unused var warning

### DIFF
--- a/rmw_connextdds_common/src/ndds/rmw_type_support_ndds.cpp
+++ b/rmw_connextdds_common/src/ndds/rmw_type_support_ndds.cpp
@@ -1039,11 +1039,11 @@ RMW_Connext_TypePlugin_instance_to_key_hash(
 // type_plugin->serializedSampleToKeyHashFnc
 RTIBool
 RMW_Connext_TypePlugin_serialized_sample_to_key_hash(
-  PRESTypePluginEndpointData endpointData,
-  struct RTICdrStream *stream,
-  struct MIGRtpsKeyHash *keyHash,
-  RTIBool deserializeEncapsulation,
-  void *endpointPluginQos)
+  PRESTypePluginEndpointData /*endpointData*/,
+  struct RTICdrStream /**stream*/,
+  struct MIGRtpsKeyHash /**keyHash*/,
+  RTIBool /*deserializeEncapsulation*/,
+  void /**endpointPluginQos*/)
 {
   return RTI_FALSE;
 }


### PR DESCRIPTION
Related with this nightly clang build https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/2219/clang/folder.-1798993873/

There are some unused variables.