### PR TITLE
:farmer: Fix cpplint regression

### DIFF
--- a/rmw_connextdds_common/src/common/rmw_type_support.cpp
+++ b/rmw_connextdds_common/src/common/rmw_type_support.cpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <exception>
 #include <string.h>
+#include <exception>
 #include <string>
 
 #include "rcpputils/scope_exit.hpp"


### PR DESCRIPTION


Fixes [projectroot.cpplint](https://ci.ros2.org/view/nightly/job/nightly_linux_debug/3396/testReport/junit/(root)/projectroot/cpplint/) regression:
```
/home/jenkins-agent/workspace/nightly_linux_debug/ws/src/ros2/rmw_connextdds/rmw_connextdds_common/src/common/rmw_type_support.cpp:16:  Found C system header after C++ system header. Should be: rmw_type_support.h, c system, c++ system, other.  [build/include_order] [4]
```

Reference build: https://ci.ros2.org/view/nightly/job/nightly_linux_debug/3396/