### PR TITLE
Correctly calculate the size of a serialized key

### DIFF
--- a/rmw_connextdds_common/include/rmw_connextdds/type_support.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/type_support.hpp
@@ -182,6 +182,8 @@ public:
     const rcutils_uint8_array_t * const from_buffer,
     const bool header_only = false);
 
+  std::size_t serialized_key_size_max(const void * const ros_msg);
+
   rmw_ret_t serialize_key(
     const void * const ros_msg,
     rcutils_uint8_array_t * const to_buffer,

--- a/rmw_connextdds_common/include/rmw_connextdds/type_support.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/type_support.hpp
@@ -15,6 +15,7 @@
 #ifndef RMW_CONNEXTDDS__TYPE_SUPPORT_HPP_
 #define RMW_CONNEXTDDS__TYPE_SUPPORT_HPP_
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <stdexcept>

--- a/rmw_connextdds_common/src/common/rmw_type_support.cpp
+++ b/rmw_connextdds_common/src/common/rmw_type_support.cpp
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <string.h>
+#include <cstddef>
+#include <cstring>
 
 #include <exception>
 #include <string>

--- a/rmw_connextdds_common/src/common/rmw_type_support.cpp
+++ b/rmw_connextdds_common/src/common/rmw_type_support.cpp
@@ -507,6 +507,12 @@ RMW_Connext_MessageTypeSupport::deserialize(
   return RMW_RET_OK;
 }
 
+std::size_t RMW_Connext_MessageTypeSupport::serialized_key_size_max(
+  const void * const ros_msg)
+{
+  return (this->keyed()) ? _key_callbacks.get_serialized_size_key(ros_msg) : 0;
+}
+
 rmw_ret_t
 RMW_Connext_MessageTypeSupport::serialize_key(
   const void * const ros_msg,

--- a/rmw_connextdds_common/src/ndds/rmw_type_support_ndds.cpp
+++ b/rmw_connextdds_common/src/ndds/rmw_type_support_ndds.cpp
@@ -984,13 +984,18 @@ RMW_Connext_TypePlugin_instance_to_key_hash(
   {
     RTICdrStream_pushState(md5_stream, &cdr_state, -1);
 
-    int size = RMW_Connext_TypePlugin_get_serialized_sample_size(
-      endpoint_data,
-      RTI_FALSE /* include_encapsulation */,
-      RTI_CDR_ENCAPSULATION_ID_CDR_BE,
-      0 /* current_alignment */,
-      sample);
+    const RMW_Connext_Message *const msg =
+      reinterpret_cast<const RMW_Connext_Message *>(sample);
+    const auto size_unsigned = (nullptr != msg->user_data) ?
+      type_support->serialized_key_size_max(msg->user_data) :
+      msg->data_buffer.buffer_length;
 
+    // Make sure the size fits in an int32
+    RMW_CONNEXT_ASSERT(size_unsigned <= std::numeric_limits<int>::max());
+    const auto size = static_cast<int>(size_unsigned);
+
+    // If there's already enough size when serializing, the serialization failed
+    // for a different reason, so we return an error
     if (size <= RTICdrStream_getBufferLength(md5_stream)) {
       RTICdrStream_popState(md5_stream, &cdr_state);
       return RTI_FALSE;

--- a/rmw_connextdds_common/src/ndds/rmw_type_support_ndds.cpp
+++ b/rmw_connextdds_common/src/ndds/rmw_type_support_ndds.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cstring>
+#include <limits>
 #include <string>
 
 #include "rcpputils/scope_exit.hpp"


### PR DESCRIPTION
## Description

This idl type:

```idl
module demo_keys_cpp {
 module msg {
  struct KeyedTestDataMsg {   
   @key string id;
   int16 data; 
   };
 };
};
```

Gives the following error:

```bash
[INFO] [1756364674.416500519] [keyed_sensor]: 0
ERROR [0x01019993,0x08289DED,0x2C926A31:0x80000002{Entity=DW,Topic=rt/robot/sensors,Type=demo_keys_cpp::msg::dds_::KeyedTestDataMsg_,Domain=1}|WRITE|ADD TO WRITER QUEUE] PRESWriterHistoryDriver_addWrite:FAILED TO GET | Key hash
ERROR [0x01019993,0x08289DED,0x2C926A31:0x80000002{Entity=DW,Topic=rt/robot/sensors,Type=demo_keys_cpp::msg::dds_::KeyedTestDataMsg_,Domain=1}|WRITE] PRESPsWriter_writeInternal:!collator addWrite
[ERROR] [1756364674.416831045] [rmw_connextdds]: failed to write message to DDS
terminate called after throwing an instance of 'rclcpp::exceptions::RCLError'
  what():  failed to publish message: failed to write message to DDS, at ./src/ndds/dds_api_ndds.cpp:778, at ./src/rcl/publisher.c:285
[ros2run]: Aborted
```

The issue happens because we are getting the wrong size when calculating the MD5 hash. Basically we are trying to allocate enough memory to hold the serialized key, but in some cases we were not getting enough. Using the correct key callback to retrieve the size of the serialized key solves the issue.

### Is this user-facing behavior change?

Keyed topics were not working with certain types. This fix allows users to use those types.

### Did you use Generative AI?

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
