### PR TITLE
[rmw_connextdds_common]: Remove <member_of_group>rosidl_interface_pac…

### DIFF
--- a/rmw_connextdds_common/package.xml
+++ b/rmw_connextdds_common/package.xml
@@ -28,8 +28,6 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 
-  <member_of_group>rosidl_interface_packages</member_of_group>
-
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
## Description

It doesn't have any messages in it, so it should not need the dependency.

### Is this user-facing behavior change?

No.

### Did you use Generative AI?

No.

### Additional Information

N/A