### PR TITLE
fix: remove superflous `buildtool_export_depend`

### DIFF
--- a/rmw_connextdds/package.xml
+++ b/rmw_connextdds/package.xml
@@ -8,8 +8,7 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_export_depend>ament_cmake</buildtool_export_depend>
-
+  
   <depend>rmw_connextdds_common</depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
As far as I understand this package does not expose an build time interface that requires `amend_cmake` so the `buildtool_export_depend` is not needed.