### PR TITLE
Use DDS_DomainParticipant_register_contentfilterI instead of DDS_ContentFilter_register_filter

### DIFF
--- a/rmw_connextdds_common/include/rmw_connextdds/custom_sql_filter.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/custom_sql_filter.hpp
@@ -50,9 +50,9 @@ extern "C" {
 // to be a replacement for the built-in SQL-like filter.
 RMW_CONNEXTDDS_PUBLIC
 DDS_ReturnCode_t DDS_DomainParticipant_register_contentfilterI(
-  DDS_DomainParticipant *participant,
-  const char *name,
-  const struct DDS_ContentFilter *filter,
+  DDS_DomainParticipant * participant,
+  const char * name,
+  const struct DDS_ContentFilter * filter,
   const DDS_ContentFilterEvaluateFunction evaluateOnSerialized,
   const DDS_ContentFilterWriterEvaluateFunction writerEvaluateOnSerialized,
   const DDS_ContentFilterQueryFunction query,

--- a/rmw_connextdds_common/include/rmw_connextdds/custom_sql_filter.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/custom_sql_filter.hpp
@@ -49,11 +49,10 @@ extern "C" {
 // be registered as "built-in". We need this because we want this custom filter
 // to be a replacement for the built-in SQL-like filter.
 RMW_CONNEXTDDS_PUBLIC
-DDS_ReturnCode_t
-DDS_ContentFilter_register_filter(
-  DDS_DomainParticipant * participant,
-  const char * name,
-  const struct DDS_ContentFilter * filter,
+DDS_ReturnCode_t DDS_DomainParticipant_register_contentfilterI(
+  DDS_DomainParticipant *participant,
+  const char *name,
+  const struct DDS_ContentFilter *filter,
   const DDS_ContentFilterEvaluateFunction evaluateOnSerialized,
   const DDS_ContentFilterWriterEvaluateFunction writerEvaluateOnSerialized,
   const DDS_ContentFilterQueryFunction query,

--- a/rmw_connextdds_common/src/ndds/custom_sql_filter.cpp
+++ b/rmw_connextdds_common/src/ndds/custom_sql_filter.cpp
@@ -788,7 +788,7 @@ rti_connext_dds_custom_sql_filter::register_content_filter(
   filter.writer_finalize = RTI_CustomSqlFilter_writer_finalize;
   filter.writer_return_loan = RTI_CustomSqlFilter_writer_return_loan;
 
-  rc = DDS_ContentFilter_register_filter(
+  rc = DDS_DomainParticipant_register_contentfilterI(
     participant,
     PLUGIN_NAME,
     &filter,


### PR DESCRIPTION
## Description

The function `DDS_ContentFilter_register_filter` is no longer visible in Connext 7.6.0, which causes the RMW build to fail. To fix the issue, we use the function `DDS_DomainParticipant_register_contentfilterI` instead, which provides the same functionality.

### Is this user-facing behavior change?

Yes, users now will be able to use the Connext RMW with Connext 7.6.0.

### Did you use Generative AI?

No