### PR TITLE
Remove default from switch with enum, so that compiler warns.

### DIFF
--- a/rmw_connextdds/src/rmw_api_impl_ndds.cpp
+++ b/rmw_connextdds/src/rmw_api_impl_ndds.cpp
@@ -1033,11 +1033,13 @@ rmw_feature_supported(rmw_feature_t feature)
 {
   switch (feature) {
     case RMW_FEATURE_MESSAGE_INFO_RECEPTION_SEQUENCE_NUMBER:
+      [[fallthrough]];
     case RMW_FEATURE_MESSAGE_INFO_PUBLICATION_SEQUENCE_NUMBER:
       {
         return true;
       }
     case RMW_MIDDLEWARE_SUPPORTS_TYPE_DISCOVERY:
+      [[fallthrough]];
     case RMW_MIDDLEWARE_CAN_TAKE_DYNAMIC_MESSAGE:
       {
         return false;

--- a/rmw_connextdds/src/rmw_api_impl_ndds.cpp
+++ b/rmw_connextdds/src/rmw_api_impl_ndds.cpp
@@ -1037,11 +1037,13 @@ rmw_feature_supported(rmw_feature_t feature)
       {
         return true;
       }
-    default:
+    case RMW_MIDDLEWARE_SUPPORTS_TYPE_DISCOVERY:
+    case RMW_MIDDLEWARE_CAN_TAKE_DYNAMIC_MESSAGE:
       {
         return false;
       }
   }
+  return false;
 }
 
 /******************************************************************************

--- a/rmw_connextdds_common/src/common/rmw_context.cpp
+++ b/rmw_connextdds_common/src/common/rmw_context.cpp
@@ -188,11 +188,6 @@ rmw_context_impl_s::initialize_discovery_options(DDS_DomainParticipantQos & dp_q
         return RMW_RET_ERROR;
       }
       break;
-    default:
-      RMW_CONNEXT_LOG_ERROR_A_SET(
-        "Unknown value provided for automatic discovery range: %i",
-        range);
-      return RMW_RET_ERROR;
   }
 
   if (RMW_AUTOMATIC_DISCOVERY_RANGE_OFF == range) {
@@ -353,7 +348,7 @@ rmw_context_impl_s::initialize_participant_qos(DDS_DomainParticipantQos & dp_qos
         }
       }
       break;
-    default:
+    case rmw_context_impl_s::participant_qos_override_policy_t::Never:
       break;
   }
 

--- a/rmw_connextdds_common/src/common/rmw_impl.cpp
+++ b/rmw_connextdds_common/src/common/rmw_impl.cpp
@@ -352,8 +352,7 @@ rmw_connextdds_get_readerwriter_qos(
         history->kind = DDS_KEEP_ALL_HISTORY_QOS;
         break;
       }
-    // case RMW_QOS_POLICY_HISTORY_UNKNOWN:
-    default:
+    case RMW_QOS_POLICY_HISTORY_UNKNOWN:
       {
         RMW_CONNEXT_LOG_ERROR_A_SET(
           "unsupported history kind: %d", qos_policies->history)
@@ -385,8 +384,8 @@ rmw_connextdds_get_readerwriter_qos(
         reliability->kind = DDS_BEST_EFFORT_RELIABILITY_QOS;
         break;
       }
-    // case RMW_QOS_POLICY_RELIABILITY_UNKNOWN:
-    default:
+    case RMW_QOS_POLICY_RELIABILITY_UNKNOWN:
+    case RMW_QOS_POLICY_RELIABILITY_BEST_AVAILABLE:
       {
         RMW_CONNEXT_LOG_ERROR_A_SET(
           "unsupported reliability kind: %d", qos_policies->reliability)
@@ -409,8 +408,8 @@ rmw_connextdds_get_readerwriter_qos(
         durability->kind = DDS_TRANSIENT_LOCAL_DURABILITY_QOS;
         break;
       }
-    // case RMW_QOS_POLICY_DURABILITY_UNKNOWN:
-    default:
+    case RMW_QOS_POLICY_DURABILITY_UNKNOWN:
+    case RMW_QOS_POLICY_DURABILITY_BEST_AVAILABLE:
       {
         RMW_CONNEXT_LOG_ERROR_A_SET(
           "unsupported durability kind: %d", qos_policies->durability)
@@ -442,8 +441,8 @@ rmw_connextdds_get_readerwriter_qos(
         liveliness->kind = DDS_MANUAL_BY_TOPIC_LIVELINESS_QOS;
         break;
       }
-    // case RMW_QOS_POLICY_LIVELINESS_UNKNOWN:
-    default:
+    case RMW_QOS_POLICY_LIVELINESS_UNKNOWN:
+    case RMW_QOS_POLICY_LIVELINESS_BEST_AVAILABLE:
       {
         RMW_CONNEXT_LOG_ERROR_A_SET(
           "unsupported liveliness kind: %d", qos_policies->liveliness)
@@ -3422,7 +3421,8 @@ ros_event_to_dds(const rmw_event_type_t ros, bool * const invalid)
       {
         return DDS_SUBSCRIPTION_MATCHED_STATUS;
       }
-    default:
+    case RMW_EVENT_INVALID:
+    case RMW_EVENT_TYPE_MAX:
       {
         if (nullptr != invalid) {
           *invalid = true;
@@ -3430,6 +3430,10 @@ ros_event_to_dds(const rmw_event_type_t ros, bool * const invalid)
         return (DDS_StatusKind)UINT32_MAX;
       }
   }
+  if (nullptr != invalid) {
+    *invalid = true;
+  }
+  return (DDS_StatusKind)UINT32_MAX;
 }
 
 const char *
@@ -3488,11 +3492,18 @@ ros_event_for_reader(const rmw_event_type_t ros)
       {
         return true;
       }
-    default:
+    case RMW_EVENT_INVALID:
+    case RMW_EVENT_LIVELINESS_LOST:
+    case RMW_EVENT_OFFERED_DEADLINE_MISSED:
+    case RMW_EVENT_OFFERED_QOS_INCOMPATIBLE:
+    case RMW_EVENT_PUBLISHER_INCOMPATIBLE_TYPE:
+    case RMW_EVENT_PUBLICATION_MATCHED:
+    case RMW_EVENT_TYPE_MAX:
       {
         return false;
       }
   }
+  return false;
 }
 
 rmw_ret_t
@@ -3550,7 +3561,13 @@ RMW_Connext_SubscriberStatusCondition::get_status(
         rc = this->get_matched_status(status);
         break;
       }
-    default:
+    case RMW_EVENT_INVALID:
+    case RMW_EVENT_LIVELINESS_LOST:
+    case RMW_EVENT_OFFERED_DEADLINE_MISSED:
+    case RMW_EVENT_OFFERED_QOS_INCOMPATIBLE:
+    case RMW_EVENT_PUBLISHER_INCOMPATIBLE_TYPE:
+    case RMW_EVENT_PUBLICATION_MATCHED:
+    case RMW_EVENT_TYPE_MAX:
       {
         RMW_CONNEXT_LOG_ERROR_A_SET(
           "unsupported subscriber qos: %d", event_type)
@@ -3609,7 +3626,14 @@ RMW_Connext_PublisherStatusCondition::get_status(
         rc = this->get_matched_status(status);
         break;
       }
-    default:
+    case RMW_EVENT_INVALID:
+    case RMW_EVENT_LIVELINESS_CHANGED:
+    case RMW_EVENT_REQUESTED_DEADLINE_MISSED:
+    case RMW_EVENT_REQUESTED_QOS_INCOMPATIBLE:
+    case RMW_EVENT_MESSAGE_LOST:
+    case RMW_EVENT_SUBSCRIPTION_INCOMPATIBLE_TYPE:
+    case RMW_EVENT_SUBSCRIPTION_MATCHED:
+    case RMW_EVENT_TYPE_MAX:
       {
         RMW_CONNEXT_LOG_ERROR_A_SET("unsupported publisher qos: %d", event_type)
         RMW_CONNEXT_ASSERT(0)

--- a/rmw_connextdds_common/src/common/rmw_impl.cpp
+++ b/rmw_connextdds_common/src/common/rmw_impl.cpp
@@ -385,6 +385,7 @@ rmw_connextdds_get_readerwriter_qos(
         break;
       }
     case RMW_QOS_POLICY_RELIABILITY_UNKNOWN:
+      [[fallthrough]];
     case RMW_QOS_POLICY_RELIABILITY_BEST_AVAILABLE:
       {
         RMW_CONNEXT_LOG_ERROR_A_SET(
@@ -409,6 +410,7 @@ rmw_connextdds_get_readerwriter_qos(
         break;
       }
     case RMW_QOS_POLICY_DURABILITY_UNKNOWN:
+      [[fallthrough]];
     case RMW_QOS_POLICY_DURABILITY_BEST_AVAILABLE:
       {
         RMW_CONNEXT_LOG_ERROR_A_SET(
@@ -442,6 +444,7 @@ rmw_connextdds_get_readerwriter_qos(
         break;
       }
     case RMW_QOS_POLICY_LIVELINESS_UNKNOWN:
+      [[fallthrough]];
     case RMW_QOS_POLICY_LIVELINESS_BEST_AVAILABLE:
       {
         RMW_CONNEXT_LOG_ERROR_A_SET(
@@ -3409,6 +3412,7 @@ ros_event_to_dds(const rmw_event_type_t ros, bool * const invalid)
         return DDS_SAMPLE_LOST_STATUS;
       }
     case RMW_EVENT_PUBLISHER_INCOMPATIBLE_TYPE:
+      [[fallthrough]];
     case RMW_EVENT_SUBSCRIPTION_INCOMPATIBLE_TYPE:
       {
         return DDS_INCONSISTENT_TOPIC_STATUS;
@@ -3422,6 +3426,7 @@ ros_event_to_dds(const rmw_event_type_t ros, bool * const invalid)
         return DDS_SUBSCRIPTION_MATCHED_STATUS;
       }
     case RMW_EVENT_INVALID:
+      [[fallthrough]];
     case RMW_EVENT_TYPE_MAX:
       {
         if (nullptr != invalid) {
@@ -3484,20 +3489,31 @@ ros_event_for_reader(const rmw_event_type_t ros)
 {
   switch (ros) {
     case RMW_EVENT_LIVELINESS_CHANGED:
+      [[fallthrough]];
     case RMW_EVENT_REQUESTED_DEADLINE_MISSED:
+      [[fallthrough]];
     case RMW_EVENT_REQUESTED_QOS_INCOMPATIBLE:
+      [[fallthrough]];
     case RMW_EVENT_MESSAGE_LOST:
+      [[fallthrough]];
     case RMW_EVENT_SUBSCRIPTION_INCOMPATIBLE_TYPE:
+      [[fallthrough]];
     case RMW_EVENT_SUBSCRIPTION_MATCHED:
       {
         return true;
       }
     case RMW_EVENT_INVALID:
+      [[fallthrough]];
     case RMW_EVENT_LIVELINESS_LOST:
+      [[fallthrough]];
     case RMW_EVENT_OFFERED_DEADLINE_MISSED:
+      [[fallthrough]];
     case RMW_EVENT_OFFERED_QOS_INCOMPATIBLE:
+      [[fallthrough]];
     case RMW_EVENT_PUBLISHER_INCOMPATIBLE_TYPE:
+      [[fallthrough]];
     case RMW_EVENT_PUBLICATION_MATCHED:
+      [[fallthrough]];
     case RMW_EVENT_TYPE_MAX:
       {
         return false;
@@ -3562,11 +3578,17 @@ RMW_Connext_SubscriberStatusCondition::get_status(
         break;
       }
     case RMW_EVENT_INVALID:
+      [[fallthrough]];
     case RMW_EVENT_LIVELINESS_LOST:
+      [[fallthrough]];
     case RMW_EVENT_OFFERED_DEADLINE_MISSED:
+      [[fallthrough]];
     case RMW_EVENT_OFFERED_QOS_INCOMPATIBLE:
+      [[fallthrough]];
     case RMW_EVENT_PUBLISHER_INCOMPATIBLE_TYPE:
+      [[fallthrough]];
     case RMW_EVENT_PUBLICATION_MATCHED:
+      [[fallthrough]];
     case RMW_EVENT_TYPE_MAX:
       {
         RMW_CONNEXT_LOG_ERROR_A_SET(
@@ -3627,12 +3649,19 @@ RMW_Connext_PublisherStatusCondition::get_status(
         break;
       }
     case RMW_EVENT_INVALID:
+      [[fallthrough]];
     case RMW_EVENT_LIVELINESS_CHANGED:
+      [[fallthrough]];
     case RMW_EVENT_REQUESTED_DEADLINE_MISSED:
+      [[fallthrough]];
     case RMW_EVENT_REQUESTED_QOS_INCOMPATIBLE:
+      [[fallthrough]];
     case RMW_EVENT_MESSAGE_LOST:
+      [[fallthrough]];
     case RMW_EVENT_SUBSCRIPTION_INCOMPATIBLE_TYPE:
+      [[fallthrough]];
     case RMW_EVENT_SUBSCRIPTION_MATCHED:
+      [[fallthrough]];
     case RMW_EVENT_TYPE_MAX:
       {
         RMW_CONNEXT_LOG_ERROR_A_SET("unsupported publisher qos: %d", event_type)

--- a/rmw_connextdds_common/src/common/rmw_impl_waitset_std.cpp
+++ b/rmw_connextdds_common/src/common/rmw_impl_waitset_std.cpp
@@ -713,6 +713,17 @@ RMW_Connext_SubscriberStatusCondition::has_status(
   const rmw_event_type_t event_type)
 {
   switch (event_type) {
+    case RMW_EVENT_INVALID:
+    case RMW_EVENT_LIVELINESS_LOST:
+    case RMW_EVENT_OFFERED_DEADLINE_MISSED:
+    case RMW_EVENT_OFFERED_QOS_INCOMPATIBLE:
+    case RMW_EVENT_PUBLISHER_INCOMPATIBLE_TYPE:
+    case RMW_EVENT_PUBLICATION_MATCHED:
+    case RMW_EVENT_TYPE_MAX:
+      {
+        RMW_CONNEXT_ASSERT(0)
+        return false;
+      }
     case RMW_EVENT_LIVELINESS_CHANGED:
       {
         return this->triggered_liveliness;
@@ -736,11 +747,6 @@ RMW_Connext_SubscriberStatusCondition::has_status(
     case RMW_EVENT_SUBSCRIPTION_MATCHED:
       {
         return this->triggered_matched;
-      }
-    default:
-      {
-        RMW_CONNEXT_ASSERT(0)
-        return false;
       }
   }
 }
@@ -963,6 +969,18 @@ RMW_Connext_PublisherStatusCondition::has_status(
   const rmw_event_type_t event_type)
 {
   switch (event_type) {
+    case RMW_EVENT_INVALID:
+    case RMW_EVENT_LIVELINESS_CHANGED:
+    case RMW_EVENT_REQUESTED_DEADLINE_MISSED:
+    case RMW_EVENT_REQUESTED_QOS_INCOMPATIBLE:
+    case RMW_EVENT_MESSAGE_LOST:
+    case RMW_EVENT_SUBSCRIPTION_INCOMPATIBLE_TYPE:
+    case RMW_EVENT_SUBSCRIPTION_MATCHED:
+    case RMW_EVENT_TYPE_MAX:
+      {
+        RMW_CONNEXT_ASSERT(0)
+        return false;
+      }
     case RMW_EVENT_LIVELINESS_LOST:
       {
         return this->triggered_liveliness;
@@ -983,9 +1001,6 @@ RMW_Connext_PublisherStatusCondition::has_status(
       {
         return this->triggered_matched;
       }
-    default:
-      RMW_CONNEXT_ASSERT(0)
-      return false;
   }
 }
 

--- a/rmw_connextdds_common/src/common/rmw_impl_waitset_std.cpp
+++ b/rmw_connextdds_common/src/common/rmw_impl_waitset_std.cpp
@@ -714,11 +714,17 @@ RMW_Connext_SubscriberStatusCondition::has_status(
 {
   switch (event_type) {
     case RMW_EVENT_INVALID:
+      [[fallthrough]];
     case RMW_EVENT_LIVELINESS_LOST:
+      [[fallthrough]];
     case RMW_EVENT_OFFERED_DEADLINE_MISSED:
+      [[fallthrough]];
     case RMW_EVENT_OFFERED_QOS_INCOMPATIBLE:
+      [[fallthrough]];
     case RMW_EVENT_PUBLISHER_INCOMPATIBLE_TYPE:
+      [[fallthrough]];
     case RMW_EVENT_PUBLICATION_MATCHED:
+      [[fallthrough]];
     case RMW_EVENT_TYPE_MAX:
       {
         RMW_CONNEXT_ASSERT(0)
@@ -749,6 +755,7 @@ RMW_Connext_SubscriberStatusCondition::has_status(
         return this->triggered_matched;
       }
   }
+  return false;
 }
 
 void
@@ -970,12 +977,19 @@ RMW_Connext_PublisherStatusCondition::has_status(
 {
   switch (event_type) {
     case RMW_EVENT_INVALID:
+      [[fallthrough]];
     case RMW_EVENT_LIVELINESS_CHANGED:
+      [[fallthrough]];
     case RMW_EVENT_REQUESTED_DEADLINE_MISSED:
+      [[fallthrough]];
     case RMW_EVENT_REQUESTED_QOS_INCOMPATIBLE:
+      [[fallthrough]];
     case RMW_EVENT_MESSAGE_LOST:
+      [[fallthrough]];
     case RMW_EVENT_SUBSCRIPTION_INCOMPATIBLE_TYPE:
+      [[fallthrough]];
     case RMW_EVENT_SUBSCRIPTION_MATCHED:
+      [[fallthrough]];
     case RMW_EVENT_TYPE_MAX:
       {
         RMW_CONNEXT_ASSERT(0)
@@ -1002,6 +1016,7 @@ RMW_Connext_PublisherStatusCondition::has_status(
         return this->triggered_matched;
       }
   }
+  return false;
 }
 
 

--- a/rmw_connextdds_common/src/common/rmw_type_support.cpp
+++ b/rmw_connextdds_common/src/common/rmw_type_support.cpp
@@ -132,7 +132,7 @@ RMW_Connext_RequestReplyMapping_Basic_serialize(
           cdr_stream << sample_rc;
           break;
         }
-      default:
+      case RMW_CONNEXT_MESSAGE_USERDATA:
         {
           RMW_CONNEXT_LOG_ERROR_A_SET(
             "invalid mapping type to serialize: %d",
@@ -196,7 +196,7 @@ RMW_Connext_RequestReplyMapping_Basic_deserialize(
           UNUSED_ARG(sample_rc);
           break;
         }
-      default:
+      case RMW_CONNEXT_MESSAGE_USERDATA:
         {
           RMW_CONNEXT_LOG_ERROR_A_SET(
             "invalid mapping type to deserialize: %d",
@@ -260,9 +260,6 @@ RMW_Connext_MessageTypeSupport::RMW_Connext_MessageTypeSupport(
         this->_type_name = type_name;
         break;
       }
-    default:
-      // should never get here
-      break;
   }
 
   RMW_Connext_MessageTypeSupport::type_info(

--- a/rmw_connextdds_common/src/ndds/dds_api_ndds.cpp
+++ b/rmw_connextdds_common/src/ndds/dds_api_ndds.cpp
@@ -87,11 +87,6 @@ rmw_connextdds_set_log_verbosity(rmw_log_severity_t severity)
         verbosity = NDDS_CONFIG_LOG_VERBOSITY_ERROR;
         break;
       }
-    default:
-      {
-        RMW_CONNEXT_LOG_ERROR_A_SET("invalid log level: %d", severity)
-        return RMW_RET_INVALID_ARGUMENT;
-      }
   }
 
   NDDS_Config_Logger_set_verbosity(logger, verbosity);
@@ -266,7 +261,7 @@ rmw_connextdds_initialize_participant_qos_impl(
         }
         break;
       }
-    default:
+    case rmw_context_impl_t::participant_qos_override_policy_t::Never:
       {
         // No customization of DomainParticipantQos request, return immediately.
         RMW_CONNEXT_LOG_DEBUG("using default Connext's DomainParticipantQos")
@@ -985,8 +980,6 @@ rmw_connextdds_filter_sample(
             rr_msg->gid, related_sample_identity.writer_guid);
           break;
         }
-      default:
-        return RMW_RET_ERROR;
     }
 
     // Convert instance handle to guid

--- a/rmw_connextdds_common/src/ndds/rmw_typecode.cpp
+++ b/rmw_connextdds_common/src/ndds/rmw_typecode.cpp
@@ -981,7 +981,7 @@ rmw_connextdds_convert_type_members(
             }
             break;
           }
-        default:
+        case RMW_CONNEXT_MESSAGE_USERDATA:
           {
             RMW_CONNEXT_LOG_ERROR_A_SET(
               "invalid message type for typecode: %d",

--- a/rmw_connextdds_common/src/rtime/dds_api_rtime.cpp
+++ b/rmw_connextdds_common/src/rtime/dds_api_rtime.cpp
@@ -414,11 +414,6 @@ rmw_connextdds_set_log_verbosity(rmw_log_severity_t severity)
         verbosity = OSAPI_LOG_VERBOSITY_ERROR;
         break;
       }
-    default:
-      {
-        RMW_CONNEXT_LOG_ERROR_A_SET("invalid log level: %d", severity)
-        return RMW_RET_INVALID_ARGUMENT;
-      }
   }
 
   OSAPI_Log_set_verbosity(verbosity);

--- a/rmw_connextddsmicro/src/rmw_api_impl_rtime.cpp
+++ b/rmw_connextddsmicro/src/rmw_api_impl_rtime.cpp
@@ -1043,7 +1043,9 @@ rmw_feature_supported(rmw_feature_t feature)
         return true;
       }
     case RMW_FEATURE_MESSAGE_INFO_RECEPTION_SEQUENCE_NUMBER:
+      [[fallthrough]];
     case RMW_MIDDLEWARE_SUPPORTS_TYPE_DISCOVERY:
+      [[fallthrough]];
     case RMW_MIDDLEWARE_CAN_TAKE_DYNAMIC_MESSAGE:
       {
         return false;

--- a/rmw_connextddsmicro/src/rmw_api_impl_rtime.cpp
+++ b/rmw_connextddsmicro/src/rmw_api_impl_rtime.cpp
@@ -1042,7 +1042,9 @@ rmw_feature_supported(rmw_feature_t feature)
       {
         return true;
       }
-    default:
+    case RMW_FEATURE_MESSAGE_INFO_RECEPTION_SEQUENCE_NUMBER:
+    case RMW_MIDDLEWARE_SUPPORTS_TYPE_DISCOVERY:
+    case RMW_MIDDLEWARE_CAN_TAKE_DYNAMIC_MESSAGE:
       {
         return false;
       }


### PR DESCRIPTION
## Description

Now the compiler will warn us if new enum values are added to it but aren't handled in this function.

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
