### PR TITLE
Update Connext from 7.3.0 to 7.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ROS 2 Middleware Layer for RTI Connext DDS
 
-This repository contains a implementation of the [ROS 2](https://docs.ros.org/en/rolling)
+This repository contains an implementation of the [ROS 2](https://docs.ros.org/en/rolling)
 RMW layer which allow developers to deploy their ROS applications on top of
 [RTI Connext DDS Professional](https://www.rti.com/products/connext-dds-professional)
 
@@ -33,11 +33,11 @@ For any questions or feedback, feel free to reach out to rti-ros-team@rti.com.
 2. Configure RTI Connext DDS Professional and/or RTI Connext DDS Micro on your
    system (see [Requirements](#rti-connext-dds-requirements)). Make the installation(s)
    available via environment variables, e.g. by using the provided
-   `rtisetenv_<architecture>.bash` script (replace `~/rti_connext_dds-7.3.0` with
+   `rtisetenv_<architecture>.bash` script (replace `~/rti_connext_dds-7.7.0` with
    the path of your Connext installation):
 
    ```sh
-    source ~/rti_connext_dds-7.3.0/resource/scripts/rtisetenv_x64Linux4gcc7.3.0.bash
+    source ~/rti_connext_dds-7.7.0/resource/scripts/rtisetenv_x64Linux4gcc8.5.0.bash
     export CONNEXTDDS_DIR=${NDDSHOME}
     ```
 
@@ -84,6 +84,7 @@ release:
 |ROS 2 Release|Branch|Status|
 |-------------|------|------|
 |Rolling      |`rolling`|Developed|
+|Kilted       |`kilted`|Supported until November 2026|
 |Iron         |`iron`|Supported until November 2024 (EOL)|
 |Humble       |`humble`|Supported until May 2027|
 |Galactic     |`galactic`|Supported until November 2022 (EOL)|
@@ -110,8 +111,8 @@ valid installation is detected, the packages will be skipped and not be built.
 
 |RMW|RTI Product|Environment Variable(s)|Required|Default|
 |---|-----------|-----------------------|--------|-------|
-|`rmw_connextdds`|RTI Connext DDS Professional 7.3.0|`CONNEXTDDS_DIR`, or `NDDSHOME`|Yes|None|
-|`rmw_connextddsmicro`|RTI Connext DDS Micro 3.x |`RTIMEHOME`|No (if RTI Connext DDS Professional 7.3.0 is available)|Guessed from contents of RTI Connext DDS Professional installation|
+|`rmw_connextdds`|RTI Connext DDS Professional 7.7.0|`CONNEXTDDS_DIR`, or `NDDSHOME`|Yes|None|
+|`rmw_connextddsmicro`|RTI Connext DDS Micro 3.x |`RTIMEHOME`|No (if RTI Connext DDS Professional 7.7.0 is available)|Guessed from contents of RTI Connext DDS Professional installation|
 
 ### Multiple versions of RTI Connext DDS Professional
 

--- a/README.md
+++ b/README.md
@@ -391,11 +391,19 @@ This variable is not used by `rmw_connextdds`.
 ### RMW_CONNEXT_USE_DEFAULT_PUBLISH_MODE
 
 `rmw_connextdds` will always set `DDS_DataWriterQos::publish_mode::kind` of
-any DataWriter it creates to `DDS_ASYNCHRONOUS_PUBLISH_MODE_QOS`, in order to
-enable out of the box support for "large data".
+any DataWriter it creates to `DDS_SYNCHRONOUS_PUBLISH_MODE_QOS`.
 
-This behavior might not be always desirable, and it can be disabled by setting
-`RMW_CONNEXT_USE_DEFAULT_PUBLISH_MODE` to a non-empty value.
+In order to enable support for "large data", it can be done by setting
+`RMW_CONNEXT_USE_DEFAULT_PUBLISH_MODE` to a non-empty value and setting the
+corresponding QoS in your XML file:
+
+```xml
+<datawriter_qos>
+    <publish_mode>
+        <kind>ASYNCHRONOUS_PUBLISH_MODE_QOS</kind>
+    </publish_mode>
+</datawriter_qos>
+```
 
 This variable is not used by `rmw_connextddsmicro`, since it doesn't
 automatically override `DDS_DataWriterQos::publish_mode::kind`.

--- a/rmw_connextdds_common/src/common/rmw_context.cpp
+++ b/rmw_connextdds_common/src/common/rmw_context.cpp
@@ -66,6 +66,7 @@ rmw_connextdds_initialize_participant_factory_qos()
   }
 
   qos.entity_factory.autoenable_created_entities = DDS_BOOLEAN_FALSE;
+  qos.monitoring.enable = DDS_BOOLEAN_FALSE;
 
   if (DDS_RETCODE_OK !=
     DDS_DomainParticipantFactory_set_qos(

--- a/rmw_connextdds_common/src/ndds/dds_api_ndds.cpp
+++ b/rmw_connextdds_common/src/ndds/dds_api_ndds.cpp
@@ -259,6 +259,12 @@ rmw_connextdds_initialize_participant_qos_impl(
           RMW_CONNEXT_LOG_ERROR_SET("failed to set user_data")
           return RMW_RET_ERROR;
         }
+
+        // Force the use of the TypeObject V1
+        dp_qos->resource_limits.type_object_max_serialized_length = 8192;
+        dp_qos->discovery_config.enabled_builtin_channels =
+        DDS_DISCOVERYCONFIG_SERVICE_REQUEST_CHANNEL;
+
         break;
       }
     case rmw_context_impl_t::participant_qos_override_policy_t::Never:

--- a/rmw_connextdds_common/src/ndds/dds_api_ndds.cpp
+++ b/rmw_connextdds_common/src/ndds/dds_api_ndds.cpp
@@ -263,7 +263,7 @@ rmw_connextdds_initialize_participant_qos_impl(
         // Force the use of the TypeObject V1
         dp_qos->resource_limits.type_object_max_serialized_length = 8192;
         dp_qos->discovery_config.enabled_builtin_channels =
-        DDS_DISCOVERYCONFIG_SERVICE_REQUEST_CHANNEL;
+          DDS_DISCOVERYCONFIG_SERVICE_REQUEST_CHANNEL;
 
         break;
       }

--- a/rmw_connextdds_common/src/ndds/dds_api_ndds.cpp
+++ b/rmw_connextdds_common/src/ndds/dds_api_ndds.cpp
@@ -525,7 +525,7 @@ rmw_connextdds_get_datawriter_qos(
   }
 
   if (!ctx->use_default_publish_mode) {
-    qos->publish_mode.kind = DDS_ASYNCHRONOUS_PUBLISH_MODE_QOS;
+    qos->publish_mode.kind = DDS_SYNCHRONOUS_PUBLISH_MODE_QOS;
   }
 
 #if RMW_CONNEXT_DEFAULT_RELIABILITY_OPTIMIZATIONS

--- a/rti_connext_dds_cmake_module/package.xml
+++ b/rti_connext_dds_cmake_module/package.xml
@@ -10,7 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
 
-  <depend>rti-connext-dds-7.3.0</depend>
+  <depend>rti-connext-dds-7.7.0</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
## Description

Update the Connext RMW to use the Connext 7.7.0 package instead of the 7.3.0 one.

Fixes #218

### Is this user-facing behavior change?

Users will now use Connext 7.7.0 as the backend of the Conenxt RMW.

### Did you use Generative AI?

No

### Additional Information

We also need to make changes in both ROS 2 CI and ROS Distro repos.
