### PR TITLE
Enable the property dds.ros.demangle_topic_and_type_names to announce the demangled topic name as a topic alias

### DIFF
--- a/rmw_connextdds_common/src/ndds/dds_api_ndds.cpp
+++ b/rmw_connextdds_common/src/ndds/dds_api_ndds.cpp
@@ -321,6 +321,25 @@ rmw_connextdds_initialize_participant_qos_impl(
   }
 #endif /* RMW_CONNEXT_FAST_ENDPOINT_DISCOVERY */
 
+  // Set dds.ros.demangle_topic_and_type_names to TRUE.
+  // This will announce a demangled topic name as a topic alias.
+  // This will enable interoperability with Connext applications using the
+  // demangled topic name. This should not impact compatibility with any other
+  // vendors, as the “mangled” topic name will still be announced as the real
+  // topic name. Set this property for versions 7.5+
+#if (RTI_DDS_VERSION_MAJOR > 7) || (RTI_DDS_VERSION_MAJOR == 7 && RTI_DDS_VERSION_MINOR >= 5)
+  if (DDS_RETCODE_OK != DDS_PropertyQosPolicyHelper_assert_property(
+    &dp_qos->property,
+    "dds.ros.demangle_topic_and_type_names",
+    "TRUE",
+    DDS_BOOLEAN_FALSE))
+  {
+    RMW_CONNEXT_LOG_ERROR_SET(
+      "failed to assert property on participant:  dds.ros.demangle_topic_and_type_names");
+    return RMW_RET_ERROR;
+  }
+#endif
+
   return RMW_RET_OK;
 }
 


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
Enable the property `dds.ros.demangle_topic_and_type_names` in the Connext RMW to announce the demangled topic name as a topic alias ([documentation](https://community.rti.com/static/documentation/connext-dds/current/doc/manuals/connext_dds_professional/properties_reference/property_full.html#dds-ros)).

This property enables interoperability with Connext applications using the demangled topic name.

### Is this user-facing behavior change?

Users using standalone Connext applications can interoperate with ROS 2 applications using the Connext RMW using the real topic names.

### Did you use Generative AI?

No

### Additional Information

This change was first introduced in Connext 7.5.0, and it's only enabled for that version onwards. When https://github.com/ros2/rmw_connextdds/issues/218 is completed, we may need to add tests for this feature, but only on our RMW.
