### PR TITLE
Enable content filtering flag

### DIFF
--- a/rmw_connextdds_common/src/common/rmw_impl.cpp
+++ b/rmw_connextdds_common/src/common/rmw_impl.cpp
@@ -2041,7 +2041,11 @@ rmw_connextdds_create_subscriber(
   rmw_subscriber->options = *subscriber_options;
   rmw_subscriber->can_loan_messages = false;
   rmw_subscriber->is_cft_enabled = rmw_sub_impl->is_cft_enabled();
+#if RMW_CONNEXT_DDS_API == RMW_CONNEXT_DDS_API_PRO
   rmw_subscriber->is_cft_supported = true;
+#else
+  rmw_subscriber->is_cft_supported = false;
+#endif
 
   if (!internal) {
     if (RMW_RET_OK != rmw_sub_impl->enable()) {

--- a/rmw_connextdds_common/src/common/rmw_impl.cpp
+++ b/rmw_connextdds_common/src/common/rmw_impl.cpp
@@ -2041,6 +2041,7 @@ rmw_connextdds_create_subscriber(
   rmw_subscriber->options = *subscriber_options;
   rmw_subscriber->can_loan_messages = false;
   rmw_subscriber->is_cft_enabled = rmw_sub_impl->is_cft_enabled();
+  rmw_subscriber->is_cft_supported = true;
 
   if (!internal) {
     if (RMW_RET_OK != rmw_sub_impl->enable()) {


### PR DESCRIPTION
## Description

In https://github.com/ros2/rcl/pull/1293, It is not good way to determine whether the current rmw implementation supports content filtering at the rcl layer. This PR moves enabling content filter flag to the rmw layer.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information
