### PR TITLE
fix: Fixed compilation on MSVC 2022

### DIFF
--- a/rmw_connextdds/CMakeLists.txt
+++ b/rmw_connextdds/CMakeLists.txt
@@ -48,6 +48,8 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 target_link_libraries(${PROJECT_NAME}
     rmw_connextdds_common::rmw_connextdds_common_pro)
 
+target_compile_definitions(${PROJECT_NAME} PRIVATE $<$<PLATFORM_ID:Windows>:NOMINMAX>)
+
 configure_rmw_library(${PROJECT_NAME})
 
 register_rmw_implementation(

--- a/rmw_connextdds_common/CMakeLists.txt
+++ b/rmw_connextdds_common/CMakeLists.txt
@@ -71,6 +71,7 @@ function(rtirmw_add_library)
             RMW_VERSION_MINOR=${rmw_VERSION_MINOR}
             RMW_VERSION_PATCH=${rmw_VERSION_PATCH}
             RMW_CONNEXT_DDS_API=RMW_CONNEXT_DDS_API_${_rti_build_API}
+            $<$<PLATFORM_ID:Windows>:NOMINMAX>
             ${_rti_build_DEFINES}
             ${_extra_defines}
     )

--- a/rmw_connextddsmicro/CMakeLists.txt
+++ b/rmw_connextddsmicro/CMakeLists.txt
@@ -55,6 +55,8 @@ target_link_libraries(${PROJECT_NAME}
   PUBLIC
     rmw_connextdds_common::rmw_connextdds_common_micro)
 
+target_compile_definitions(${PROJECT_NAME} PRIVATE $<$<PLATFORM_ID:Windows>:NOMINMAX>)
+
 configure_rmw_library(${PROJECT_NAME})
 
 register_rmw_implementation(


### PR DESCRIPTION
windows defines a min and max macro which causes compilation errors in rmw_connextdds_common. 
This commit undefines those macros to allow the code to compile successfully.

