### PR TITLE
Use reference counting for Topics deletion

### DIFF
--- a/rmw_connextdds_common/include/rmw_connextdds/context.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/context.hpp
@@ -19,6 +19,7 @@
 #include <mutex>
 #include <regex>
 #include <string>
+#include <unordered_map>
 
 #include "rmw_connextdds/dds_api.hpp"
 #include "rmw_connextdds/log.hpp"

--- a/rmw_connextdds_common/include/rmw_connextdds/context.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/context.hpp
@@ -132,6 +132,7 @@ public:
   bool is_shutdown{false};
 
   std::map<std::string, RMW_Connext_MessageTypeSupport *> registered_types;
+  std::unordered_map<DDS_Topic *, std::size_t> topic_ref_counts;
   std::mutex endpoint_mutex;
 
   explicit rmw_context_impl_s(rmw_context_t * const base);
@@ -153,8 +154,15 @@ public:
     const char * const topic_name,
     const char * const type_name,
     const bool internal,
-    DDS_Topic ** const topic,
-    bool & created);
+    DDS_Topic ** const topic);
+
+  void
+  retain_topic(DDS_Topic * const topic);
+
+  bool
+  release_topic(
+    DDS_DomainParticipant * const participant,
+    DDS_Topic * const topic);
 
   rmw_ret_t
   finalize();

--- a/rmw_connextdds_common/include/rmw_connextdds/rmw_impl.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/rmw_impl.hpp
@@ -341,7 +341,6 @@ public:
 private:
   DDS_DataWriter * dds_writer;
   RMW_Connext_MessageTypeSupport * type_support;
-  const bool created_topic;
   rmw_gid_t ros_gid;
   RMW_Connext_PublisherStatusCondition status_condition;
   std::mutex matched_mutex;
@@ -360,8 +359,7 @@ private:
   RMW_Connext_Publisher(
     rmw_context_impl_t * const ctx,
     DDS_DataWriter * const dds_writer,
-    RMW_Connext_MessageTypeSupport * const type_support,
-    const bool created_topic);
+    RMW_Connext_MessageTypeSupport * const type_support);
 
   void
   pop_related_endpoints(const rmw_gid_t & endpoint)
@@ -661,7 +659,6 @@ private:
   std::string cft_expression;
   RMW_Connext_MessageTypeSupport * type_support;
   rmw_gid_t ros_gid;
-  const bool created_topic;
   RMW_Connext_SubscriberStatusCondition status_condition;
   RMW_Connext_UntypedSampleSeq loan_data;
   DDS_SampleInfoSeq loan_info;
@@ -676,7 +673,6 @@ private:
     DDS_Topic * const dds_topic,
     RMW_Connext_MessageTypeSupport * const type_support,
     const bool ignore_local,
-    const bool created_topic,
     DDS_TopicDescription * const dds_topic_cft,
     const char * const cft_expression,
     const bool internal,

--- a/rmw_connextdds_common/src/common/rmw_context.cpp
+++ b/rmw_connextdds_common/src/common/rmw_context.cpp
@@ -860,32 +860,18 @@ rmw_context_impl_s::assert_topic(
   const char * const topic_name,
   const char * const type_name,
   const bool internal,
-  DDS_Topic ** const topic,
-  bool & created)
+  DDS_Topic ** const topic)
 {
   DDS_TopicDescription * const topic_existing =
     DDS_DomainParticipant_lookup_topicdescription(participant, topic_name);
 
   if (nullptr != topic_existing) {
-    if (internal) {
-      /* topics for "internal" endpoints are created while the participant
-         is still disabled, so find_topic() cannot be called.
-         Instead, we cast the topicdescription to a topic. The deletion
-         path will have to keep track that the endpoint didn't create
-         its topic, so not to try to delete it */
-      *topic = DDS_Topic_narrow(topic_existing);
-      created = false;
-    } else {
-      *topic =
-        DDS_DomainParticipant_find_topic(
-        participant,
-        DDS_TopicDescription_get_name(topic_existing),
-        &DDS_DURATION_ZERO);
-      if (nullptr == *topic) {
-        RMW_CONNEXT_LOG_ERROR_SET("failed to find topic from description")
-        return RMW_RET_ERROR;
-      }
-      created = true;
+    // Reuse the existing topic entity and rely on context-level ref counting
+    // to make topic deletion independent from endpoint destruction order.
+    *topic = DDS_Topic_narrow(topic_existing);
+    if (nullptr == *topic) {
+      RMW_CONNEXT_LOG_ERROR_SET("failed to narrow topic from description")
+      return RMW_RET_ERROR;
     }
     RMW_CONNEXT_LOG_DEBUG_A(
       "found topic: name=%s, type=%s\n",
@@ -902,20 +888,58 @@ rmw_context_impl_s::assert_topic(
       RMW_CONNEXT_LOG_ERROR_SET("failed to create reader's topic")
       return RMW_RET_ERROR;
     }
-    created = true;
     RMW_CONNEXT_LOG_DEBUG_A(
       "created topic: name=%s, type=%s\n",
       topic_name, type_name);
   }
 
+  this->retain_topic(*topic);
+
   if (!internal) {
     if (DDS_RETCODE_OK != DDS_Entity_enable(DDS_Topic_as_entity(*topic))) {
       RMW_CONNEXT_LOG_ERROR_SET("failed to enable topic")
+      if (!this->release_topic(participant, *topic)) {
+        RMW_CONNEXT_LOG_ERROR("failed to release topic after enable failure")
+      }
       return RMW_RET_ERROR;
     }
   }
 
   return RMW_RET_OK;
+}
+
+void
+rmw_context_impl_s::retain_topic(DDS_Topic * const topic)
+{
+  if (!this->topic_ref_counts.contains(topic)) {
+    this->topic_ref_counts.emplace(topic, 1);
+  } else {
+    ++this->topic_ref_counts[topic];
+  }
+}
+
+bool
+rmw_context_impl_s::release_topic(
+  DDS_DomainParticipant * const participant,
+  DDS_Topic * const topic)
+{
+  if (!this->topic_ref_counts.contains(topic)) {
+    RMW_CONNEXT_LOG_ERROR_SET("failed to release unknown topic reference")
+    return false;
+  }
+
+  // Only release the topic when no other entities reference it
+  if (--this->topic_ref_counts[topic] > 0) {
+    return true;
+  }
+
+  this->topic_ref_counts.erase(topic);
+  if (DDS_RETCODE_OK != DDS_DomainParticipant_delete_topic(participant, topic)) {
+    RMW_CONNEXT_LOG_ERROR_SET("failed to delete DDS Topic")
+    return false;
+  }
+
+  return true;
 }
 
 /******************************************************************************

--- a/rmw_connextdds_common/src/common/rmw_impl.cpp
+++ b/rmw_connextdds_common/src/common/rmw_impl.cpp
@@ -770,8 +770,7 @@ RMW_Connext_Publisher::create(
   auto scope_exit_topic_delete = rcpputils::make_scope_exit(
     [ctx, dp, topic]()
     {
-      if (!ctx->release_topic(dp, topic))
-      {
+      if (!ctx->release_topic(dp, topic)) {
         RMW_CONNEXT_LOG_ERROR_SET(
           "failed to delete writer's topic")
       }
@@ -1386,8 +1385,7 @@ RMW_Connext_Subscriber::create(
           RMW_CONNEXT_LOG_ERROR("failed to delete content-filtered topic")
         }
       }
-      if (!ctx->release_topic(dp, topic))
-      {
+      if (!ctx->release_topic(dp, topic)) {
         RMW_CONNEXT_LOG_ERROR_SET(
           "failed to delete reader's topic")
       }

--- a/rmw_connextdds_common/src/common/rmw_impl.cpp
+++ b/rmw_connextdds_common/src/common/rmw_impl.cpp
@@ -668,12 +668,10 @@ RMW_Connext_Node::finalize()
 RMW_Connext_Publisher::RMW_Connext_Publisher(
   rmw_context_impl_t * const ctx,
   DDS_DataWriter * const dds_writer,
-  RMW_Connext_MessageTypeSupport * const type_support,
-  const bool created_topic)
+  RMW_Connext_MessageTypeSupport * const type_support)
 : ctx(ctx),
   dds_writer(dds_writer),
   type_support(type_support),
-  created_topic(created_topic),
   status_condition(dds_writer),
   matched_subscriptions(DDS_SEQUENCE_INITIALIZER)
 {
@@ -751,7 +749,6 @@ RMW_Connext_Publisher::create(
   }
 
   DDS_Topic * topic = nullptr;
-  bool topic_created = false;
 
   if (RMW_RET_OK !=
     ctx->assert_topic(
@@ -759,8 +756,7 @@ RMW_Connext_Publisher::create(
       fqtopic_name.c_str(),
       type_support->type_name(),
       internal,
-      &topic,
-      topic_created))
+      &topic))
   {
     RMW_CONNEXT_LOG_ERROR_A(
       "failed to assert topic: "
@@ -772,15 +768,12 @@ RMW_Connext_Publisher::create(
   }
 
   auto scope_exit_topic_delete = rcpputils::make_scope_exit(
-    [topic_created, dp, topic]()
+    [ctx, dp, topic]()
     {
-      if (topic_created) {
-        if (DDS_RETCODE_OK !=
-        DDS_DomainParticipant_delete_topic(dp, topic))
-        {
-          RMW_CONNEXT_LOG_ERROR_SET(
-            "failed to delete writer's topic")
-        }
+      if (!ctx->release_topic(dp, topic))
+      {
+        RMW_CONNEXT_LOG_ERROR_SET(
+          "failed to delete writer's topic")
       }
     });
 
@@ -846,7 +839,7 @@ RMW_Connext_Publisher::create(
 
   RMW_Connext_Publisher * rmw_pub_impl =
     new (std::nothrow) RMW_Connext_Publisher(
-    ctx, dds_writer, type_support, topic_created);
+    ctx, dds_writer, type_support);
 
   if (nullptr == rmw_pub_impl) {
     RMW_CONNEXT_LOG_ERROR_SET("failed to allocate RMW publisher")
@@ -879,22 +872,16 @@ RMW_Connext_Publisher::finalize()
   }
 
   DDS_DomainParticipant * const participant = this->dds_participant();
+  DDS_Topic * const topic = this->dds_topic();
 
-  if (this->created_topic) {
-    DDS_Topic * const topic = this->dds_topic();
+  RMW_CONNEXT_LOG_DEBUG_A(
+    "deleting topic: name=%s",
+    DDS_TopicDescription_get_name(
+      DDS_Topic_as_topicdescription(topic)))
 
-    RMW_CONNEXT_LOG_DEBUG_A(
-      "deleting topic: name=%s",
-      DDS_TopicDescription_get_name(
-        DDS_Topic_as_topicdescription(topic)))
-
-    DDS_ReturnCode_t rc =
-      DDS_DomainParticipant_delete_topic(participant, topic);
-
-    if (DDS_RETCODE_OK != rc) {
-      RMW_CONNEXT_LOG_ERROR_SET("failed to delete DDS Topic")
-      return RMW_RET_ERROR;
-    }
+  if (!this->ctx->release_topic(participant, topic)) {
+    RMW_CONNEXT_LOG_ERROR_SET("failed to delete DDS Topic")
+    return RMW_RET_ERROR;
   }
 
   rmw_ret_t rc = RMW_Connext_MessageTypeSupport::unregister_type_support(
@@ -1279,7 +1266,6 @@ RMW_Connext_Subscriber::RMW_Connext_Subscriber(
   DDS_Topic * const dds_topic,
   RMW_Connext_MessageTypeSupport * const type_support,
   const bool ignore_local,
-  const bool created_topic,
   DDS_TopicDescription * const dds_topic_cft,
   const char * const cft_expression,
   const bool internal,
@@ -1292,7 +1278,6 @@ RMW_Connext_Subscriber::RMW_Connext_Subscriber(
   dds_topic_cft(dds_topic_cft),
   cft_expression(cft_expression),
   type_support(type_support),
-  created_topic(created_topic),
   status_condition(dds_reader, ignore_local, internal),
   related_pub(related_pub)
 {
@@ -1373,7 +1358,6 @@ RMW_Connext_Subscriber::create(
 
   DDS_Topic * topic = nullptr;
   DDS_TopicDescription * cft_topic = nullptr;
-  bool topic_created = false;
 
   if (RMW_RET_OK !=
     ctx->assert_topic(
@@ -1381,8 +1365,7 @@ RMW_Connext_Subscriber::create(
       fqtopic_name.c_str(),
       type_support->type_name(),
       internal,
-      &topic,
-      topic_created))
+      &topic))
   {
     RMW_CONNEXT_LOG_ERROR_A(
       "failed to assert topic: "
@@ -1394,7 +1377,7 @@ RMW_Connext_Subscriber::create(
   }
 
   auto scope_exit_topic_delete = rcpputils::make_scope_exit(
-    [ctx, &topic_created, dp, &topic, &cft_topic]()
+    [ctx, dp, &topic, &cft_topic]()
     {
       if (nullptr != cft_topic) {
         if (RMW_RET_OK !=
@@ -1403,13 +1386,10 @@ RMW_Connext_Subscriber::create(
           RMW_CONNEXT_LOG_ERROR("failed to delete content-filtered topic")
         }
       }
-      if (topic_created) {
-        if (DDS_RETCODE_OK !=
-        DDS_DomainParticipant_delete_topic(dp, topic))
-        {
-          RMW_CONNEXT_LOG_ERROR_SET(
-            "failed to delete reader's topic")
-        }
+      if (!ctx->release_topic(dp, topic))
+      {
+        RMW_CONNEXT_LOG_ERROR_SET(
+          "failed to delete reader's topic")
       }
     });
 
@@ -1515,7 +1495,6 @@ RMW_Connext_Subscriber::create(
     topic,
     type_support,
     subscriber_options->ignore_local_publications,
-    topic_created,
     cft_topic,
     sub_cft_expr,
     internal,
@@ -1569,21 +1548,16 @@ RMW_Connext_Subscriber::finalize()
     }
   }
 
-  if (this->created_topic) {
-    DDS_Topic * const topic = this->dds_topic;
+  DDS_Topic * const topic = this->dds_topic;
 
-    RMW_CONNEXT_LOG_DEBUG_A(
-      "deleting topic: name=%s",
-      DDS_TopicDescription_get_name(
-        DDS_Topic_as_topicdescription(topic)))
+  RMW_CONNEXT_LOG_DEBUG_A(
+    "deleting topic: name=%s",
+    DDS_TopicDescription_get_name(
+      DDS_Topic_as_topicdescription(topic)))
 
-    DDS_ReturnCode_t rc =
-      DDS_DomainParticipant_delete_topic(participant, topic);
-
-    if (DDS_RETCODE_OK != rc) {
-      RMW_CONNEXT_LOG_ERROR_SET("failed to delete DDS Topic")
-      return RMW_RET_ERROR;
-    }
+  if (!this->ctx->release_topic(participant, topic)) {
+    RMW_CONNEXT_LOG_ERROR_SET("failed to delete DDS Topic")
+    return RMW_RET_ERROR;
   }
 
   rmw_ret_t rc = RMW_Connext_MessageTypeSupport::unregister_type_support(


### PR DESCRIPTION
## Description

Handle memory for Topics creation and deletion by using a custom reference counter. This further simplifies the code and memory management.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

Yes. Initial solution generated with GitHub Copilot in Auto mode, and later manually modified.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
