### PR TITLE
Enable Monitoring Library by default

### DIFF
--- a/rmw_connextdds_common/src/common/rmw_context.cpp
+++ b/rmw_connextdds_common/src/common/rmw_context.cpp
@@ -69,7 +69,6 @@ rmw_connextdds_initialize_participant_factory_qos()
   }
 
   qos.entity_factory.autoenable_created_entities = DDS_BOOLEAN_FALSE;
-  qos.monitoring.enable = DDS_BOOLEAN_FALSE;
 
   if (DDS_RETCODE_OK !=
     DDS_DomainParticipantFactory_set_qos(

--- a/rmw_connextdds_common/src/ndds/dds_api_ndds.cpp
+++ b/rmw_connextdds_common/src/ndds/dds_api_ndds.cpp
@@ -159,6 +159,34 @@ rmw_connextdds_finalize_participant_factory_context(
   for (DDS_Long i = 0; i < pending; i++) {
     DDS_DomainParticipant * const participant =
       *DDS_DomainParticipantSeq_get_reference(&participants, i);
+
+    DDS_DomainParticipantQos qos = DDS_DomainParticipantQos_INITIALIZER;
+    auto scope_exit_qos = rcpputils::make_scope_exit(
+      [&qos]() {
+        if (DDS_RETCODE_OK != DDS_DomainParticipantQos_finalize(&qos)) {
+          RMW_CONNEXT_LOG_ERROR_SET("failed to finalize participant QoS")
+        }
+      });
+    if (DDS_RETCODE_OK != DDS_DomainParticipant_get_qos(participant, &qos)) {
+      RMW_CONNEXT_LOG_ERROR_SET("failed to get participant QoS")
+      continue;
+    }
+
+    DDS_Boolean isMonitoring2Participant = DDS_BOOLEAN_FALSE;
+    if (DDS_RETCODE_OK == DDS_PropertyQosPolicyHelper_lookup_boolean_property(
+        &qos.property,
+        &isMonitoring2Participant,
+        PROPERTY_NAME_RTI_MONITORING2_PARTICIPANT,
+        DDS_BOOLEAN_FALSE))
+    {
+      if (DDS_BOOLEAN_TRUE == isMonitoring2Participant) {
+        // If this is a dedicated Participant created by Monitoring 2.0, its
+        // deletion is done when the DomainParticipantFactory is finalized.
+        //
+        // For that reason, skip the deletion of this Participant here.
+        continue;
+      }
+    }
 #if RMW_CONNEXT_DEBUG
     // If we are building in Debug mode, an issue in Connext may prevent the
     // participant from being able to delete any content-filtered topic if


### PR DESCRIPTION
## Description

This pull request enables the Monitoring Library in the Connext RMW by default.

### Is this user-facing behavior change?

The Connext RMW will now send monitoring data by default.

### Did you use Generative AI?

No

### Additional Information

We had to disable the monitoring library as we were very close to the Lyrical code freeze.
