### PR TITLE
Add Keyed Topics unit tests along with unit tests skeleton

### DIFF
--- a/rmw_connextdds/CMakeLists.txt
+++ b/rmw_connextdds/CMakeLists.txt
@@ -59,6 +59,25 @@ register_rmw_implementation(
 if(BUILD_TESTING)
     find_package(ament_lint_auto REQUIRED)
     ament_lint_auto_find_test_dependencies()
+
+
+    find_package(ament_cmake_gtest REQUIRED)
+    find_package(osrf_testing_tools_cpp REQUIRED)
+    find_package(rmw REQUIRED)
+    find_package(test_msgs REQUIRED)
+
+    ament_add_gtest(test_keyed_topics test/test_keyed_topics.cpp)
+    if(TARGET test_keyed_topics)
+        target_sources(test_keyed_topics PRIVATE test/test_utils.hpp)
+        target_link_libraries(test_keyed_topics
+            osrf_testing_tools_cpp::memory_tools
+            rcutils::rcutils
+            rmw::rmw
+            RTIConnextDDS::cpp2_api
+            ${PROJECT_NAME}
+            ${test_msgs_TARGETS}
+        )
+    endif()
 endif()
 
 install(

--- a/rmw_connextdds/package.xml
+++ b/rmw_connextdds/package.xml
@@ -11,8 +11,12 @@
   
   <depend>rmw_connextdds_common</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>osrf_testing_tools_cpp</test_depend>
+  <test_depend>rmw</test_depend>
+  <test_depend>test_msgs</test_depend>
 
   <member_of_group>rmw_implementation_packages</member_of_group>
 

--- a/rmw_connextdds/test/test_keyed_topics.cpp
+++ b/rmw_connextdds/test/test_keyed_topics.cpp
@@ -216,7 +216,7 @@ TYPED_TEST(TestKeyedTopics, test_keyhash)
     rmw_connextdds::test::wait_for(
       [&publication_listener]
       {
-        return publication_listener->get_type() != nullptr;
+        return std::nullopt != publication_listener->get_type();
       }));
 
   auto topic = dds::topic::Topic<dds::core::xtypes::DynamicData>(

--- a/rmw_connextdds/test/test_keyed_topics.cpp
+++ b/rmw_connextdds/test/test_keyed_topics.cpp
@@ -292,10 +292,12 @@ TYPED_TEST(TestKeyedTopics, test_keyhash)
   ASSERT_TRUE(
     rmw_connextdds::test::wait_for(
       [&] {
-        for (const auto & sample : reader.take()) {
-          if (sample.info().valid()) {
-            dds_received_messages_from_ros.first.push_back(sample.info().instance_handle());
-            dds_received_messages_from_ros.second.push_back(sample.data());
+        auto sample_data = dds::core::xtypes::DynamicData(*publication_listener->get_type());
+        auto sample_info = dds::sub::SampleInfo();
+        while (reader.extensions().take(sample_data, sample_info)) {
+          if (sample_info.valid()) {
+            dds_received_messages_from_ros.first.push_back(sample_info.instance_handle());
+            dds_received_messages_from_ros.second.push_back(sample_data);
           }
         }
         return dds_message_instances.size() == dds_received_messages_from_ros.second.size();
@@ -320,10 +322,12 @@ TYPED_TEST(TestKeyedTopics, test_keyhash)
   ASSERT_TRUE(
     rmw_connextdds::test::wait_for(
       [&] {
-        for (const auto & sample : reader.take()) {
-          if (sample.info().valid()) {
-            dds_received_messages_from_dds.first.push_back(sample.info().instance_handle());
-            dds_received_messages_from_dds.second.push_back(sample.data());
+        auto sample_data = dds::core::xtypes::DynamicData(*publication_listener->get_type());
+        auto sample_info = dds::sub::SampleInfo();
+        while (reader.extensions().take(sample_data, sample_info)) {
+          if (sample_info.valid()) {
+            dds_received_messages_from_dds.first.push_back(sample_info.instance_handle());
+            dds_received_messages_from_dds.second.push_back(sample_data);
           }
         }
         return dds_message_instances.size() == dds_received_messages_from_dds.second.size();

--- a/rmw_connextdds/test/test_keyed_topics.cpp
+++ b/rmw_connextdds/test/test_keyed_topics.cpp
@@ -1,0 +1,365 @@
+// Copyright 2026 Real-Time Innovations, Inc. (RTI)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <type_traits>
+#include <cstdio>
+#include <filesystem>
+
+#include "test_utils.hpp"
+
+#include "gtest/gtest.h"
+
+#include "osrf_testing_tools_cpp/scope_exit.hpp"
+
+#include "test_msgs/msg/keyed_long.hpp"
+#include "test_msgs/msg/keyed_string.hpp"
+#include "test_msgs/message_fixtures.hpp"
+
+#include "rmw/rmw.h"
+#include "rmw/error_handling.h"
+
+#include "rcutils/allocator.h"
+#include "rcutils/strdup.h"
+
+#include <dds/core/xtypes/DynamicData.hpp>
+#include <dds/dds.hpp>
+#include <rti/rti.hpp>
+
+namespace
+{
+constexpr auto ros_node_name = "test_node";
+constexpr auto ros_node_namespace = "/test_namespace";
+constexpr auto ros_topic_name = "/test";
+
+constexpr auto connext_topic_name = "rt/test";
+
+template<typename T>
+dds::core::xtypes::DynamicData to_dynamic_data(
+  const T & message,
+  const dds::core::xtypes::DynamicType & type);
+
+template<>
+dds::core::xtypes::DynamicData to_dynamic_data(
+  const test_msgs::msg::KeyedString & message,
+  const dds::core::xtypes::DynamicType & type)
+{
+  auto dds_data = dds::core::xtypes::DynamicData(type);
+  dds_data.value("key", message.key);
+  dds_data.value("value", message.value);
+  return dds_data;
+}
+
+template<>
+dds::core::xtypes::DynamicData to_dynamic_data(
+  const test_msgs::msg::KeyedLong & message,
+  const dds::core::xtypes::DynamicType & type)
+{
+  auto dds_data = dds::core::xtypes::DynamicData(type);
+  dds_data.value("key", message.key);
+  dds_data.value("value", message.value);
+  return dds_data;
+}
+
+template<typename T>
+auto get_messages()
+{
+  if constexpr (std::is_same_v<T, test_msgs::msg::KeyedString>) {
+    return get_messages_keyed_string();
+  } else if constexpr (std::is_same_v<T, test_msgs::msg::KeyedLong>) {
+    return get_messages_keyed_long();
+  } else {
+    static_assert(false, "Unsupported type");
+  }
+}
+
+}  // namespace
+
+template<typename TestType>
+class TestKeyedTopics : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    auto options = rmw_get_zero_initialized_init_options();
+    auto ret = rmw_init_options_init(&options, rcutils_get_default_allocator());
+    ASSERT_EQ(RMW_RET_OK, ret) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      auto ret = rmw_init_options_fini(&options);
+      EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+    });
+    options.enclave = rcutils_strdup("/", rcutils_get_default_allocator());
+    ASSERT_STREQ("/", options.enclave);
+    ret = rmw_init(&options, &context);
+    ASSERT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+    node = rmw_create_node(&context, ros_node_name, ros_node_namespace);
+    ASSERT_NE(nullptr, node) << rmw_get_error_string().str;
+  }
+
+  void TearDown() override
+  {
+    auto ret = rmw_destroy_node(node);
+    EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+    ret = rmw_shutdown(&context);
+    EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+    ret = rmw_context_fini(&context);
+    EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+
+    // Explicitly finalize the participant factory to avoid invalid memory
+    // access errors when running multiple tests in the same process.
+    dds::domain::DomainParticipant::finalize_participant_factory();
+  }
+
+  rmw_context_t context{rmw_get_zero_initialized_context()};
+  rmw_node_t *node{nullptr};
+};
+
+using KeyedTypes = ::testing::Types<
+  test_msgs::msg::KeyedLong,
+  test_msgs::msg::KeyedString>;
+
+struct KeyedTypesNameGenerator
+{
+  template<typename T>
+  static std::string GetName([[maybe_unused]] int idx)
+  {
+    if constexpr (std::is_same_v<T, test_msgs::msg::KeyedLong>) {
+      return "KeyedLong";
+    }
+    if constexpr (std::is_same_v<T, test_msgs::msg::KeyedString>) {
+      return "KeyedString";
+    }
+
+    return "";
+  }
+};
+
+TYPED_TEST_SUITE(TestKeyedTopics, KeyedTypes, KeyedTypesNameGenerator);
+
+// Create a ROS publisher and subscriber.
+// Create a DDS DataWriter and DataReader.
+// Publish with ROS two samples from different instances.
+// Make sure we receive the samples with ROS.
+// Read the samples with Connext:
+// - Take the instance handle of both samples and convert them to GUID
+// - Check that GUID has the expected value:
+//   - For that, we publish two samples with DDS.
+//   - Check the instance handles received from both ROS and DDS are equal.
+TYPED_TEST(TestKeyedTopics, test_keyhash)
+{
+  const auto * ts =
+    rosidl_typesupport_cpp::get_message_type_support_handle<TypeParam>();
+  rmw_qos_profile_t qos_profile = rmw_qos_profile_default;
+  qos_profile.durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
+
+  // Create RMW publisher
+  auto publisher_options = rmw_get_default_publisher_options();
+  rmw_publisher_t *pub = rmw_create_publisher(
+    this->node,
+    ts,
+    ros_topic_name,
+    &qos_profile,
+    &publisher_options);
+  ASSERT_NE(nullptr, pub) << rmw_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    EXPECT_EQ(RMW_RET_OK, rmw_destroy_publisher(this->node, pub)) << rmw_get_error_string().str;
+  );
+
+  // Create RMW subscriber
+  auto subscription_options = rmw_get_default_subscription_options();
+  rmw_subscription_t *sub = rmw_create_subscription(
+    this->node,
+    ts,
+    ros_topic_name,
+    &qos_profile,
+    &subscription_options);
+  ASSERT_NE(nullptr, sub) << rmw_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    EXPECT_EQ(RMW_RET_OK, rmw_destroy_subscription(this->node, sub)) << rmw_get_error_string().str;
+  );
+
+  // Configure the participant factory to manually enable entities
+  auto factory_qos = dds::domain::DomainParticipant::participant_factory_qos();
+  factory_qos << dds::core::policy::EntityFactory::ManuallyEnable();
+  dds::domain::DomainParticipant::participant_factory_qos(factory_qos);
+
+  // Create Domain Participant
+  auto participant = dds::domain::DomainParticipant(this->context.actual_domain_id);
+
+  // Create shared pointer to BuiltinParticipantListener class
+  auto publication_listener =
+    std::make_shared<rmw_connextdds::test::ROSTypeFinderListener>(connext_topic_name);
+
+  // Get builtin subscriber's datareader for publications.
+  auto publication_reader =
+    std::vector<dds::sub::DataReader<dds::topic::PublicationBuiltinTopicData>>();
+  dds::sub::find<dds::sub::DataReader<dds::topic::PublicationBuiltinTopicData>>(
+    dds::sub::builtin_subscriber(participant),
+    dds::topic::publication_topic_name(),
+    std::back_inserter(publication_reader));
+
+  publication_reader.front().set_listener(publication_listener);
+  participant.enable();
+
+  ASSERT_TRUE(
+    rmw_connextdds::test::wait_for(
+      [&publication_listener]
+      {
+        return publication_listener->get_type() != nullptr;
+      }));
+
+  auto topic = dds::topic::Topic<dds::core::xtypes::DynamicData>(
+    participant,
+    connext_topic_name,
+    *publication_listener->get_type());
+
+  // Create a Reliable DataWriter
+  auto writer_qos = dds::core::QosProvider::Default().datawriter_qos();
+  writer_qos << dds::core::policy::Reliability::Reliable();
+  writer_qos << dds::core::policy::Durability::TransientLocal();
+  auto writer = dds::pub::DataWriter<dds::core::xtypes::DynamicData>(topic, writer_qos);
+
+  // Create a Reliable DataReader
+  auto reader_qos = dds::core::QosProvider::Default().datareader_qos();
+  reader_qos << dds::core::policy::Reliability::Reliable();
+  reader_qos << dds::core::policy::Durability::TransientLocal();
+  reader_qos << rti::core::policy::Property().set({
+    "dds.data_reader.history.memory_manager.fast_pool.pool_buffer_max_size",
+    "8192"
+  });
+  auto reader = dds::sub::DataReader<dds::core::xtypes::DynamicData>(topic, reader_qos);
+
+  // Create RMW messages to be published
+  const auto rmw_message_instances = get_messages<TypeParam>();
+  // Publish the RMW messages
+  for (const auto & rmw_message_instance : rmw_message_instances) {
+    const auto ret = rmw_publish(pub, rmw_message_instance.get(), nullptr);
+    EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+  }
+
+  // Read ROS messages using ROS
+  auto rmw_received_messages = decltype(rmw_message_instances)();
+
+  // Take RMW samples
+  ASSERT_TRUE(
+    rmw_connextdds::test::wait_for([&]{
+      auto rmw_output_message = TypeParam();
+      auto taken = false;
+      const auto ret = rmw_take(sub, &rmw_output_message, &taken, nullptr);
+      EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+
+      if (taken) {
+        rmw_received_messages.push_back(
+          std::make_shared<TypeParam>(std::move(rmw_output_message)));
+      }
+
+      return rmw_message_instances.size() == rmw_received_messages.size();
+    }));
+
+  ASSERT_TRUE(
+    std::is_permutation(
+      rmw_received_messages.begin(),
+      rmw_received_messages.end(),
+      rmw_message_instances.begin(),
+      [](const auto & lhs, const auto & rhs) {
+        return *lhs == *rhs;
+      }));
+
+  // Create DDS messages to be published
+  auto dds_message_instances = std::vector<dds::core::xtypes::DynamicData>();
+  for (const auto & rmw_message_instance : rmw_message_instances) {
+    dds_message_instances.push_back(
+      to_dynamic_data(*rmw_message_instance, *publication_listener->get_type()));
+  }
+
+  // Read ROS messages using DDS
+  auto dds_received_messages_from_ros = std::pair<
+    std::vector<dds::core::InstanceHandle>,
+    std::vector<dds::core::xtypes::DynamicData>>();
+
+  // Take RMW samples data and instance handles
+  ASSERT_TRUE(
+    rmw_connextdds::test::wait_for(
+      [&] {
+        for (const auto & sample : reader.take()) {
+          if (sample.info().valid()) {
+            dds_received_messages_from_ros.first.push_back(sample.info().instance_handle());
+            dds_received_messages_from_ros.second.push_back(sample.data());
+          }
+        }
+        return dds_message_instances.size() == dds_received_messages_from_ros.second.size();
+    }));
+
+  ASSERT_TRUE(std::is_permutation(
+    dds_received_messages_from_ros.second.begin(),
+    dds_received_messages_from_ros.second.end(),
+    dds_message_instances.begin()));
+
+  // Publish the DDS messages
+  for (const auto & dds_message_instance : dds_message_instances) {
+    writer.write(dds_message_instance);
+  }
+
+  // Read DDS messages using DDS
+  auto dds_received_messages_from_dds = std::pair<
+    std::vector<dds::core::InstanceHandle>,
+    std::vector<dds::core::xtypes::DynamicData>>();
+
+  // Take DDS samples data and instance handles
+  ASSERT_TRUE(
+    rmw_connextdds::test::wait_for(
+      [&] {
+        for (const auto & sample : reader.take()) {
+          if (sample.info().valid()) {
+            dds_received_messages_from_dds.first.push_back(sample.info().instance_handle());
+            dds_received_messages_from_dds.second.push_back(sample.data());
+          }
+        }
+        return dds_message_instances.size() == dds_received_messages_from_dds.second.size();
+    }));
+
+  ASSERT_TRUE(std::is_permutation(
+    dds_received_messages_from_dds.second.begin(),
+    dds_received_messages_from_dds.second.end(),
+    dds_message_instances.begin()));
+
+  // Check that the instance handles are the same
+  ASSERT_EQ(dds_received_messages_from_ros.first, dds_received_messages_from_dds.first);
+
+  // Read DDS samples with ROS
+  rmw_received_messages.clear();
+  ASSERT_TRUE(
+    rmw_connextdds::test::wait_for([&]{
+      auto rmw_output_message = TypeParam();
+      auto taken = false;
+      const auto ret = rmw_take(sub, &rmw_output_message, &taken, nullptr);
+      EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+
+      if (taken) {
+        rmw_received_messages.push_back(
+          std::make_shared<TypeParam>(std::move(rmw_output_message)));
+      }
+
+      return rmw_message_instances.size() == rmw_received_messages.size();
+    }));
+
+  ASSERT_TRUE(
+    std::is_permutation(
+      rmw_received_messages.begin(),
+      rmw_received_messages.end(),
+      rmw_message_instances.begin(),
+      [](const auto & lhs, const auto & rhs) {
+        return *lhs == *rhs;
+      }));
+}

--- a/rmw_connextdds/test/test_utils.hpp
+++ b/rmw_connextdds/test/test_utils.hpp
@@ -60,20 +60,19 @@ public:
     dds::sub::DataReader<dds::topic::PublicationBuiltinTopicData> & reader) override
   {
     // We only process newly seen subscribers
-    const auto samples =
-      reader.select().state(dds::sub::status::DataState::new_instance()).take();
+    auto sample_data = dds::topic::PublicationBuiltinTopicData();
+    auto sample_info = dds::sub::SampleInfo();
+    while (reader.extensions().take(sample_data, sample_info)) {
+      if (!sample_info.valid() ||
+        sample_data.topic_name().to_std_string() != topic_name_ ||
+        !sample_data.extensions().type().has_value())
+      {
+        continue;
+      }
 
-    const auto sample_found = std::ranges::find_if(
-      samples,
-      [this](const auto & sample) {
-        return sample.info().valid() &&
-               sample.data().topic_name().to_std_string() == topic_name_ &&
-               sample.data().extensions().get_type_no_copy().has_value();
-      });
-
-    if (sample_found != samples.end()) {
-      type_ = sample_found->data().extensions().type().value();
+      type_ = sample_data.extensions().type().value();
       reader.set_listener(nullptr);
+      break;
     }
   }
 

--- a/rmw_connextdds/test/test_utils.hpp
+++ b/rmw_connextdds/test/test_utils.hpp
@@ -52,7 +52,7 @@ class ROSTypeFinderListener
 {
 public:
   explicit ROSTypeFinderListener(const std::string & topic_name)
-  : topic_name(topic_name) {}
+  : topic_name_(topic_name) {}
   // This gets called when a subscriber has been discovered
   void on_data_available(
     dds::sub::DataReader<dds::topic::PublicationBuiltinTopicData> & reader) override
@@ -66,23 +66,26 @@ public:
         continue;
       }
 
-      if (sample.data().topic_name().to_std_string() == topic_name &&
-        sample.data()->get_type_no_copy().has_value())
-      {
-        type = std::make_unique<dds::core::xtypes::DynamicType>(sample.data()->type().value());
-        break;
+      if (sample.data().topic_name().to_std_string() != topic_name_) {
+        continue;
       }
+
+      if (!sample.data()->get_type_no_copy().has_value()) {
+        continue;
+      }
+
+      type_ = std::make_unique<dds::core::xtypes::DynamicType>(sample.data()->type().value());
     }
   }
 
   const std::unique_ptr<dds::core::xtypes::DynamicType> & get_type() const
   {
-    return type;
+    return type_;
   }
 
 private:
-  std::unique_ptr<dds::core::xtypes::DynamicType> type;
-  std::string topic_name;
+  std::unique_ptr<dds::core::xtypes::DynamicType> type_;
+  std::string topic_name_;
 };
 
 }  // namespace rmw_connextdds::test

--- a/rmw_connextdds/test/test_utils.hpp
+++ b/rmw_connextdds/test/test_utils.hpp
@@ -14,8 +14,9 @@
 
 #pragma once
 
+#include <algorithm>
 #include <chrono>
-#include <memory>
+#include <optional>
 #include <string>
 #include <thread>
 
@@ -53,38 +54,36 @@ class ROSTypeFinderListener
 public:
   explicit ROSTypeFinderListener(const std::string & topic_name)
   : topic_name_(topic_name) {}
+
   // This gets called when a subscriber has been discovered
   void on_data_available(
     dds::sub::DataReader<dds::topic::PublicationBuiltinTopicData> & reader) override
   {
     // We only process newly seen subscribers
-    dds::sub::LoanedSamples<dds::topic::PublicationBuiltinTopicData> samples =
+    const auto samples =
       reader.select().state(dds::sub::status::DataState::new_instance()).take();
 
-    for (const auto & sample : samples) {
-      if (!sample.info().valid()) {
-        continue;
-      }
+    const auto sample_found = std::ranges::find_if(
+      samples,
+      [this](const auto & sample) {
+        return sample.info().valid() &&
+               sample.data().topic_name().to_std_string() == topic_name_ &&
+               sample.data().extensions().get_type_no_copy().has_value();
+      });
 
-      if (sample.data().topic_name().to_std_string() != topic_name_) {
-        continue;
-      }
-
-      if (!sample.data()->get_type_no_copy().has_value()) {
-        continue;
-      }
-
-      type_ = std::make_unique<dds::core::xtypes::DynamicType>(sample.data()->type().value());
+    if (sample_found != samples.end()) {
+      type_ = sample_found->data().extensions().type().value();
+      reader.set_listener(nullptr);
     }
   }
 
-  const std::unique_ptr<dds::core::xtypes::DynamicType> & get_type() const
+  const std::optional<dds::core::xtypes::DynamicType> & get_type() const
   {
     return type_;
   }
 
 private:
-  std::unique_ptr<dds::core::xtypes::DynamicType> type_;
+  std::optional<dds::core::xtypes::DynamicType> type_;
   std::string topic_name_;
 };
 

--- a/rmw_connextdds/test/test_utils.hpp
+++ b/rmw_connextdds/test/test_utils.hpp
@@ -1,0 +1,88 @@
+// Copyright 2026 Real-Time Innovations, Inc. (RTI)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include <dds/sub/DataReader.hpp>
+#include <dds/sub/DataReaderListener.hpp>
+#include <dds/sub/LoanedSamples.hpp>
+#include <dds/topic/BuiltinTopic.hpp>
+
+namespace rmw_connextdds::test
+{
+
+template<
+  typename Cond,
+  typename Duration1 = std::chrono::seconds,
+  typename Duration2 = std::chrono::milliseconds>
+bool wait_for(
+  Cond condition,
+  const Duration1 & timeout = Duration1(10),
+  const Duration2 & interval = Duration2(100))
+{
+  const auto end_time = std::chrono::steady_clock::now() + timeout;
+  while (std::chrono::steady_clock::now() < end_time) {
+    if (condition()) {
+      return true;
+    }
+    std::this_thread::sleep_for(interval);
+  }
+  return false;
+}
+
+class ROSTypeFinderListener
+  : public dds::sub::NoOpDataReaderListener<
+    dds::topic::PublicationBuiltinTopicData>
+{
+public:
+  explicit ROSTypeFinderListener(const std::string & topic_name)
+  : topic_name(topic_name) {}
+  // This gets called when a subscriber has been discovered
+  void on_data_available(
+    dds::sub::DataReader<dds::topic::PublicationBuiltinTopicData> & reader) override
+  {
+    // We only process newly seen subscribers
+    dds::sub::LoanedSamples<dds::topic::PublicationBuiltinTopicData> samples =
+      reader.select().state(dds::sub::status::DataState::new_instance()).take();
+
+    for (const auto & sample : samples) {
+      if (!sample.info().valid()) {
+        continue;
+      }
+
+      if (sample.data().topic_name().to_std_string() == topic_name &&
+        sample.data()->get_type_no_copy().has_value())
+      {
+        type = std::make_unique<dds::core::xtypes::DynamicType>(sample.data()->type().value());
+        break;
+      }
+    }
+  }
+
+  const std::unique_ptr<dds::core::xtypes::DynamicType> & get_type() const
+  {
+    return type;
+  }
+
+private:
+  std::unique_ptr<dds::core::xtypes::DynamicType> type;
+  std::string topic_name;
+};
+
+}  // namespace rmw_connextdds::test


### PR DESCRIPTION
## Description

Added unit tests for Keyed Topics, along with an initial skeleton for unit testing inside `rmw_connextdds`.

These tests check that the instance handles sent by the RMW are the ones expected by Connext.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
