### PR TITLE
Disable monitoring on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,19 @@ is sped up from 3 seconds to 100 milliseconds.
 These optimizations may be disabled using variable
 `RMW_CONNEXT_DISABLE_RELIABILITY_OPTIMIZATIONS`.
 
+### RTI_MONITORING2_ENABLE
+
+By default, Connext enables [RTI Monitoring Library 2.0](https://community.rti.com/static/documentation/connext-dds/current/doc/manuals/connext_dds_professional/observability/library.html)
+on the DomainParticipantFactory. This can be changed in an XML QoS profile via
+the `<monitoring>` settings or by setting the environment variable
+`RTI_MONITORING2_ENABLE`. Setting `RTI_MONITORING2_ENABLE` to false will disable
+the Monitoring Library. For more information on enabling and using the 
+RTI Monitoring 2.0 Library, see [Enabling Monitoring Library 2.0](https://community.rti.com/static/documentation/connext-dds/current/doc/manuals/connext_dds_professional/observability/library.html#enabling-monitoringlibrary2-heading).
+
+Monitoring is currently disabled entirely on Windows to avoid an access
+violation during process teardown (see
+[rmw_connextdds#248](https://github.com/ros2/rmw_connextdds/issues/248)).
+
 ### RMW_CONNEXT_ENDPOINT_QOS_OVERRIDE_POLICY
 
 When this variable is not set or set to `always`, the QoS settings specified in

--- a/rmw_connextdds_common/src/common/rmw_context.cpp
+++ b/rmw_connextdds_common/src/common/rmw_context.cpp
@@ -69,6 +69,11 @@ rmw_connextdds_initialize_participant_factory_qos()
   }
 
   qos.entity_factory.autoenable_created_entities = DDS_BOOLEAN_FALSE;
+#ifdef RTI_WIN32
+  // Disable monitoring on windows due to issues with cleanup of monitoring
+  // resources
+  qos.monitoring.enable = DDS_BOOLEAN_FALSE;
+#endif
 
   if (DDS_RETCODE_OK !=
     DDS_DomainParticipantFactory_set_qos(


### PR DESCRIPTION
## Description

Fixes #248
Disable RTI Monitoring on Windows
Update README.md to describe existing RTI_MONITORING2_ENABLE environment variable

### Is this user-facing behavior change?

Yes, monitoring will now be disabled by default on Windows

### Did you use Generative AI?

No

### Additional Information